### PR TITLE
Fix/non closed channel

### DIFF
--- a/client/src/main/java/jp/co/soramitsu/iroha/java/IrohaAPI.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/IrohaAPI.java
@@ -32,7 +32,7 @@ import lombok.val;
 /**
  * Class which provides convenient RX abstraction over Iroha API.
  */
-public class IrohaAPI implements Closeable, AutoCloseable {
+public class IrohaAPI implements Closeable {
 
   private static final SubscriptionStrategy defaultStrategy = new WaitForTerminalStatus();
 

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/IrohaAPI.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/IrohaAPI.java
@@ -32,7 +32,7 @@ import lombok.val;
 /**
  * Class which provides convenient RX abstraction over Iroha API.
  */
-public class IrohaAPI implements Closeable {
+public class IrohaAPI implements Closeable, AutoCloseable {
 
   private static final SubscriptionStrategy defaultStrategy = new WaitForTerminalStatus();
 
@@ -63,14 +63,6 @@ public class IrohaAPI implements Closeable {
     );
 
     this.uri = new URI("grpc", null, host, port, null, null, null);
-
-    // set single thread executor for streaming query stub as default
-    this.setChannelForStreamingQueryStub(ManagedChannelBuilder
-        .forAddress(host, port)
-        .directExecutor()
-        .usePlaintext()
-        .build()
-    );
   }
 
   public IrohaAPI(ManagedChannel channel) {
@@ -194,7 +186,7 @@ public class IrohaAPI implements Closeable {
       boolean terminated = false;
       do {
         try {
-          terminated = channel.awaitTermination(10, TimeUnit.MILLISECONDS);
+          terminated = channel.awaitTermination(30, TimeUnit.SECONDS);
         } catch (InterruptedException e) {
           Exceptions.propagate(e);
         }

--- a/client/src/test/groovy/jp/co/soramitsu/iroha/java/ConcurrencyTest.groovy
+++ b/client/src/test/groovy/jp/co/soramitsu/iroha/java/ConcurrencyTest.groovy
@@ -1,11 +1,13 @@
 package jp.co.soramitsu.iroha.java
 
+import io.grpc.ManagedChannel
 import io.grpc.ManagedChannelBuilder
 import io.reactivex.internal.observers.LambdaObserver
 import iroha.protocol.QryResponses.BlockQueryResponse
 import jp.co.soramitsu.iroha.testcontainers.IrohaContainer
 import spock.lang.Specification
 
+import java.util.concurrent.TimeUnit
 import java.util.stream.IntStream
 
 import static jp.co.soramitsu.iroha.testcontainers.detail.GenesisBlockBuilder.*
@@ -21,22 +23,24 @@ class ConcurrencyTest extends Specification {
 
     static IrohaAPI api
 
-    static def defaultExecutorChannel
+    static ManagedChannel directExecutorChannel
 
     def setupSpec() {
         iroha.start()
         api = iroha.api
 
         def t = iroha.getToriiAddress()
-        defaultExecutorChannel = ManagedChannelBuilder.forAddress(t.host, t.port)
-            .directExecutor()
-            .usePlaintext()
-            .build()
+        directExecutorChannel = ManagedChannelBuilder.forAddress(t.host, t.port)
+                .directExecutor()
+                .usePlaintext()
+                .build()
 
-        api.setChannelForStreamingQueryStub(defaultExecutorChannel)
+        api.setChannelForStreamingQueryStub(directExecutorChannel)
     }
 
     def cleanupSpec() {
+        directExecutorChannel.shutdownNow()
+        directExecutorChannel.awaitTermination(30, TimeUnit.SECONDS)
         iroha.stop()
     }
 

--- a/client/src/test/groovy/jp/co/soramitsu/iroha/java/ConcurrencyTest.groovy
+++ b/client/src/test/groovy/jp/co/soramitsu/iroha/java/ConcurrencyTest.groovy
@@ -21,9 +21,19 @@ class ConcurrencyTest extends Specification {
 
     static IrohaAPI api
 
+    static def defaultExecutorChannel
+
     def setupSpec() {
         iroha.start()
         api = iroha.api
+
+        def t = iroha.getToriiAddress()
+        defaultExecutorChannel = ManagedChannelBuilder.forAddress(t.host, t.port)
+            .directExecutor()
+            .usePlaintext()
+            .build()
+
+        api.setChannelForStreamingQueryStub(defaultExecutorChannel)
     }
 
     def cleanupSpec() {


### PR DESCRIPTION
Sometimes you may get the following error:
```
Feb 18, 2019 3:42:40 PM io.grpc.internal.ManagedChannelOrphanWrapper$ManagedChannelReference cleanQueue
SEVERE: *~*~*~ Channel ManagedChannelImpl{logId=io.grpc.internal.ManagedChannelImpl-5, target=localhost:32787} was not shutdown properly!!! ~*~*~*
    Make sure to call shutdown()/shutdownNow() and wait until awaitTermination() returns true.
java.lang.RuntimeException: ManagedChannel allocation site
```

This is because `ManagedChannel` with direct executor, which was implicitly created for streaming blocks stream, was not properly closed.