### PR TITLE
static counter

### DIFF
--- a/client/src/main/java/jp/co/soramitsu/iroha/java/QueryAPI.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/QueryAPI.java
@@ -39,7 +39,7 @@ public class QueryAPI {
     this.keyPair = account.getKeyPair();
   }
 
-  private AtomicInteger counter = new AtomicInteger(1);
+  private static AtomicInteger counter = new AtomicInteger(1);
 
   private void checkErrorResponse(QueryResponse response) {
     if (response.hasErrorResponse()) {


### PR DESCRIPTION
Query counter is made static in order to build queries from different instances.

Signed-off-by: Alexey Chernyshov <alexey.n.chernyshov@gmail.com>