### PR TITLE
Explicit dependency type for grpc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: required
+dist: trusty
 services:
   - docker
 addons:

--- a/client/proto.gradle
+++ b/client/proto.gradle
@@ -9,7 +9,7 @@ repositories {
 
 dependencies {
     compile "com.google.protobuf:protobuf-java:${protobufVersion}"
-    compile "io.grpc:protoc-gen-grpc-java:${grpcVersion}"
+    compile group: 'io.grpc', name: 'protoc-gen-grpc-java', version: grpcVersion, ext: 'pom'
     compile "io.grpc:grpc-stub:${grpcVersion}"
     compile "io.grpc:grpc-protobuf:${grpcVersion}"
     compile "io.grpc:grpc-core:${grpcVersion}"


### PR DESCRIPTION
Faced problem during configuration of jmeter-maven-plugin, it's can not collect grpc dependency because default type is 'jar' not 'pom'