### PR TITLE
Feature/update iroha 1.2.0

### DIFF
--- a/client/build.gradle
+++ b/client/build.gradle
@@ -10,7 +10,8 @@ repositories {
 }
 
 final def spockVersion = '1.2-groovy-2.4'
-final def edVersion = '2.0.1'
+final def edSha3Version = '2.0.1'
+final def edDsaVersion = '0.3.0'
 final def spockGenesisVersion = '0.6.0'
 final def lombokVersion = '1.18.4'
 final def rxjavaVersion = '2.2.4'
@@ -22,7 +23,8 @@ final def objgenesisVersion = '3.0.1'
 
 dependencies {
     compile "io.reactivex.rxjava2:rxjava:${rxjavaVersion}"
-    compile("com.github.warchant:ed25519-sha3-java:${edVersion}")
+    compile "com.github.warchant:ed25519-sha3-java:${edSha3Version}"
+    compile "net.i2p.crypto:eddsa:${edDsaVersion}"
 
     compileOnly("org.projectlombok:lombok:$lombokVersion")
     testCompileOnly("org.projectlombok:lombok:$lombokVersion")

--- a/client/build.gradle
+++ b/client/build.gradle
@@ -37,6 +37,8 @@ dependencies {
     testCompile("net.bytebuddy:byte-buddy:${bytebuddyVersion}")
     testCompile("org.objenesis:objenesis:${objgenesisVersion}")
     testCompile("cglib:cglib-nodep:${cglibVersion}")
+
+    implementation 'javax.annotation:javax.annotation-api:1.3.2'
 }
 
 apply from: 'proto.gradle'

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/BlocksQuery.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/BlocksQuery.java
@@ -22,7 +22,7 @@ public class BlocksQuery
     super(Payload.newBuilder());
 
     this.meta = meta;
-    signatureBuilder = new Ed25519Sha3SignatureBuilder();
+    signatureBuilder = Ed25519Sha3SignatureBuilder.getInstance();
   }
 
   public BlocksQuery(QueryPayloadMeta.Builder meta, SignatureBuilder signatureBuilder) {

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/BlocksQuery.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/BlocksQuery.java
@@ -7,18 +7,29 @@ import java.security.KeyPair;
 import java.time.Instant;
 import java.util.Date;
 import jp.co.soramitsu.crypto.ed25519.Ed25519Sha3.CryptoException;
+import jp.co.soramitsu.iroha.java.crypto.Ed25519Sha3SignatureBuilder;
+import jp.co.soramitsu.iroha.java.crypto.SignatureBuilder;
 import jp.co.soramitsu.iroha.java.detail.Hashable;
 
 public class BlocksQuery
     extends Hashable<Payload.Builder> {
 
   private QueryPayloadMeta.Builder meta;
+  private SignatureBuilder signatureBuilder;
   private Queries.BlocksQuery.Builder q = Queries.BlocksQuery.newBuilder();
 
   public BlocksQuery(QueryPayloadMeta.Builder meta) {
     super(Payload.newBuilder());
 
     this.meta = meta;
+    signatureBuilder = new Ed25519Sha3SignatureBuilder();
+  }
+
+  public BlocksQuery(QueryPayloadMeta.Builder meta, SignatureBuilder signatureBuilder) {
+    super(Payload.newBuilder());
+
+    this.meta = meta;
+    this.signatureBuilder = signatureBuilder;
   }
 
   public byte[] payload() {
@@ -32,7 +43,7 @@ public class BlocksQuery
 
   public Queries.BlocksQuery buildSigned(KeyPair keyPair) throws CryptoException {
     updatePayload();
-    q.setSignature(Utils.sign(this, keyPair));
+    q.setSignature(signatureBuilder.sign(this, keyPair));
     return q.build();
   }
 

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/FieldValidator.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/FieldValidator.java
@@ -155,9 +155,16 @@ public class FieldValidator {
   }
 
   public void checkPublicKey(@NonNull byte[] peerKey) {
-    if (peerKey.length != 32) {
-      throw new ValidationException(PUBKEY, "Public key must be 32 bytes length, got '%d'",
+    if (peerKey.length != 32 && peerKey.length != 35) {
+      throw new ValidationException(PUBKEY, "Public key must be 32 or 44 bytes length, got '%d'",
           peerKey.length);
+    }
+  }
+
+  public void checkPublicKey(@NonNull String peerKey) {
+    if (peerKey.length() != 64 && ((peerKey.length() != 70) || !peerKey.toLowerCase().startsWith("ed0120"))) {
+      throw new ValidationException(PUBKEY, "Public key must be 64 or 70 hex length with supported format, got '%d'",
+              peerKey.length());
     }
   }
 

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/FieldValidator.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/FieldValidator.java
@@ -1,30 +1,7 @@
 package jp.co.soramitsu.iroha.java;
 
-import static jp.co.soramitsu.iroha.java.ValidationException.Type.ACCOUNT_ID;
-import static jp.co.soramitsu.iroha.java.ValidationException.Type.ACCOUNT_NAME;
-import static jp.co.soramitsu.iroha.java.ValidationException.Type.AMOUNT;
-import static jp.co.soramitsu.iroha.java.ValidationException.Type.ASSET_ID;
-import static jp.co.soramitsu.iroha.java.ValidationException.Type.ASSET_NAME;
-import static jp.co.soramitsu.iroha.java.ValidationException.Type.DESCRIPTION;
-import static jp.co.soramitsu.iroha.java.ValidationException.Type.DETAILS_KEY;
-import static jp.co.soramitsu.iroha.java.ValidationException.Type.DETAILS_VALUE;
-import static jp.co.soramitsu.iroha.java.ValidationException.Type.DOMAIN;
-import static jp.co.soramitsu.iroha.java.ValidationException.Type.HASH_LENGTH;
-import static jp.co.soramitsu.iroha.java.ValidationException.Type.PAGE_SIZE;
-import static jp.co.soramitsu.iroha.java.ValidationException.Type.PEER_ADDRESS;
-import static jp.co.soramitsu.iroha.java.ValidationException.Type.PRECISION;
-import static jp.co.soramitsu.iroha.java.ValidationException.Type.PUBKEY;
-import static jp.co.soramitsu.iroha.java.ValidationException.Type.QUORUM;
-import static jp.co.soramitsu.iroha.java.ValidationException.Type.ROLE_NAME;
-import static jp.co.soramitsu.iroha.java.ValidationException.Type.TIMESTAMP;
-import static jp.co.soramitsu.iroha.java.detail.Const.accountDetailsKeyPattern;
-import static jp.co.soramitsu.iroha.java.detail.Const.accountDetailsMaxLength;
-import static jp.co.soramitsu.iroha.java.detail.Const.accountIdDelimiter;
-import static jp.co.soramitsu.iroha.java.detail.Const.accountPattern;
-import static jp.co.soramitsu.iroha.java.detail.Const.assetIdDelimiter;
-import static jp.co.soramitsu.iroha.java.detail.Const.assetNamePattern;
-import static jp.co.soramitsu.iroha.java.detail.Const.hostPortDelimiter;
-import static jp.co.soramitsu.iroha.java.detail.Const.roleNamePattern;
+import static jp.co.soramitsu.iroha.java.ValidationException.Type.*;
+import static jp.co.soramitsu.iroha.java.detail.Const.*;
 
 import java.math.BigDecimal;
 import java.net.URI;
@@ -165,6 +142,18 @@ public class FieldValidator {
     }
   }
 
+  public void checkEvmAddress(@NonNull String address) {
+    val m = evmAddress.matcher(address);
+    if (!m.matches()) {
+      throw new ValidationException(
+              EVM_ADDRESS,
+              "Invalid EVM address. Expected '%s', got '%s'",
+              evmAddress.pattern(),
+              address
+      );
+    }
+  }
+
   public void checkPublicKey(@NonNull byte[] peerKey) {
     if (peerKey.length != 32) {
       throw new ValidationException(PUBKEY, "Public key must be 32 bytes length, got '%d'",
@@ -226,6 +215,18 @@ public class FieldValidator {
     if (length != 64) {
       throw new ValidationException(HASH_LENGTH, "Hash length must be equal to 64, got '%d'",
           length);
+    }
+  }
+
+  public void checkHexString(@NonNull String string) {
+    val m = hexString.matcher(string);
+    if (!m.matches()) {
+      throw new ValidationException(
+              HEX_STRING,
+              "Invalid hex string. Expected '%s', got '%s'",
+              hexString.pattern(),
+              string
+      );
     }
   }
 }

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/Query.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/Query.java
@@ -23,7 +23,7 @@ public class Query
     super(Payload.newBuilder());
 
     this.meta = meta;
-    signatureBuilder = new Ed25519Sha3SignatureBuilder();
+    signatureBuilder = Ed25519Sha3SignatureBuilder.getInstance();
   }
 
   public Query(QueryPayloadMeta.Builder meta, SignatureBuilder signatureBuilder) {
@@ -37,7 +37,7 @@ public class Query
     super(queryBuilder.getPayload().toBuilder());
 
     this.meta = queryBuilder.getPayload().getMeta().toBuilder();
-    signatureBuilder = new Ed25519Sha3SignatureBuilder();
+    signatureBuilder = Ed25519Sha3SignatureBuilder.getInstance();
   }
 
   public Query(QueryOrBuilder queryBuilder, SignatureBuilder signatureBuilder) {

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/Query.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/Query.java
@@ -8,24 +8,43 @@ import java.security.KeyPair;
 import java.time.Instant;
 import java.util.Date;
 import jp.co.soramitsu.crypto.ed25519.Ed25519Sha3.CryptoException;
+import jp.co.soramitsu.iroha.java.crypto.Ed25519Sha3SignatureBuilder;
+import jp.co.soramitsu.iroha.java.crypto.SignatureBuilder;
 import jp.co.soramitsu.iroha.java.detail.Hashable;
 
 public class Query
     extends Hashable<Payload.Builder> {
 
   private QueryPayloadMeta.Builder meta;
+  private SignatureBuilder signatureBuilder;
   private Queries.Query.Builder q = Queries.Query.newBuilder();
 
   public Query(QueryPayloadMeta.Builder meta) {
     super(Payload.newBuilder());
 
     this.meta = meta;
+    signatureBuilder = new Ed25519Sha3SignatureBuilder();
+  }
+
+  public Query(QueryPayloadMeta.Builder meta, SignatureBuilder signatureBuilder) {
+    super(Payload.newBuilder());
+
+    this.meta = meta;
+    this.signatureBuilder = signatureBuilder;
   }
 
   public Query(QueryOrBuilder queryBuilder) {
     super(queryBuilder.getPayload().toBuilder());
 
     this.meta = queryBuilder.getPayload().getMeta().toBuilder();
+    signatureBuilder = new Ed25519Sha3SignatureBuilder();
+  }
+
+  public Query(QueryOrBuilder queryBuilder, SignatureBuilder signatureBuilder) {
+    super(queryBuilder.getPayload().toBuilder());
+
+    this.meta = queryBuilder.getPayload().getMeta().toBuilder();
+    this.signatureBuilder = signatureBuilder;
   }
 
   private void updatePayload() {
@@ -35,7 +54,7 @@ public class Query
 
   public Queries.Query buildSigned(KeyPair keyPair) throws CryptoException {
     updatePayload();
-    q.setSignature(Utils.sign(this, keyPair));
+    q.setSignature(signatureBuilder.sign(this, keyPair));
     return q.build();
   }
 
@@ -58,5 +77,21 @@ public class Query
 
   public static QueryBuilder builder(String accountId, long counter) {
     return new QueryBuilder(accountId, Instant.now(), counter);
+  }
+
+  public static QueryBuilder builder(String accountId, Long time, long counter, SignatureBuilder signatureBuilder) {
+    return new QueryBuilder(accountId, time, counter, signatureBuilder);
+  }
+
+  public static QueryBuilder builder(String accountId, Date time, long counter, SignatureBuilder signatureBuilder) {
+    return new QueryBuilder(accountId, time, counter, signatureBuilder);
+  }
+
+  public static QueryBuilder builder(String accountId, Instant time, long counter, SignatureBuilder signatureBuilder) {
+    return new QueryBuilder(accountId, time, counter, signatureBuilder);
+  }
+
+  public static QueryBuilder builder(String accountId, long counter, SignatureBuilder signatureBuilder) {
+    return new QueryBuilder(accountId, Instant.now(), counter, signatureBuilder);
   }
 }

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/QueryAPI.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/QueryAPI.java
@@ -18,6 +18,8 @@ import java.security.KeyPair;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import jp.co.soramitsu.iroha.java.crypto.Ed25519Sha3SignatureBuilder;
+import jp.co.soramitsu.iroha.java.crypto.SignatureBuilder;
 import jp.co.soramitsu.iroha.java.debug.Account;
 import lombok.Getter;
 import lombok.NonNull;
@@ -33,16 +35,35 @@ public class QueryAPI {
   @NonNull
   private KeyPair keyPair;
 
+  // default signature builder
+  private SignatureBuilder signatureBuilder;
+
   public QueryAPI(IrohaAPI api, String accountId, KeyPair keyPair) {
     this.api = api;
     this.accountId = accountId;
     this.keyPair = keyPair;
+    signatureBuilder = new Ed25519Sha3SignatureBuilder();
+  }
+
+  public QueryAPI(IrohaAPI api, String accountId, KeyPair keyPair, SignatureBuilder signatureBuilder) {
+    this.api = api;
+    this.accountId = accountId;
+    this.keyPair = keyPair;
+    this.signatureBuilder = signatureBuilder;
   }
 
   public QueryAPI(IrohaAPI api, Account account) {
     this.api = api;
     this.accountId = account.getId();
     this.keyPair = account.getKeyPair();
+    signatureBuilder = new Ed25519Sha3SignatureBuilder();
+  }
+
+  public QueryAPI(IrohaAPI api, Account account, SignatureBuilder signatureBuilder) {
+    this.api = api;
+    this.accountId = account.getId();
+    this.keyPair = account.getKeyPair();
+    this.signatureBuilder = signatureBuilder;
   }
 
   private static AtomicInteger counter = new AtomicInteger(1);
@@ -55,7 +76,7 @@ public class QueryAPI {
   }
 
   public EngineReceiptsResponse getEngineReceipts(String txHash) {
-    val q = Query.builder(this.accountId, counter.getAndIncrement())
+    val q = Query.builder(this.accountId, counter.getAndIncrement(), signatureBuilder)
             .getEngineReceipts(txHash)
             .buildSigned(keyPair);
 
@@ -67,7 +88,7 @@ public class QueryAPI {
   }
 
   public PeersResponse getPeers() {
-    val q = Query.builder(this.accountId, counter.getAndIncrement())
+    val q = Query.builder(this.accountId, counter.getAndIncrement(), signatureBuilder)
         .getPeers()
         .buildSigned(keyPair);
 
@@ -89,7 +110,7 @@ public class QueryAPI {
       String writer,
       String key
   ) {
-    val q = Query.builder(this.accountId, counter.getAndIncrement())
+    val q = Query.builder(this.accountId, counter.getAndIncrement(), signatureBuilder)
         .getAccountDetail(accountId, writer, key)
         .buildSigned(keyPair);
 
@@ -110,7 +131,7 @@ public class QueryAPI {
       String accountDetailRecordIdWriter,
       String accountDetailRecordIdKey
   ) {
-    val q = Query.builder(this.accountId, counter.getAndIncrement())
+    val q = Query.builder(this.accountId, counter.getAndIncrement(), signatureBuilder)
         .getAccountDetail(
             accountId,
             writer,
@@ -138,7 +159,7 @@ public class QueryAPI {
   }
 
   public AccountResponse getAccount(String accountId) {
-    val q = Query.builder(this.accountId, counter.getAndIncrement())
+    val q = Query.builder(this.accountId, counter.getAndIncrement(), signatureBuilder)
         .getAccount(accountId)
         .buildSigned(keyPair);
 
@@ -150,7 +171,7 @@ public class QueryAPI {
   }
 
   public BlockResponse getBlock(Long height) {
-    val q = Query.builder(this.accountId, counter.getAndIncrement())
+    val q = Query.builder(this.accountId, counter.getAndIncrement(), signatureBuilder)
         .getBlock(height)
         .buildSigned(keyPair);
 
@@ -165,7 +186,7 @@ public class QueryAPI {
                                                          Integer pageSize,
                                                          String firstHashHex,
                                                          QueryBuilder.Ordering ordering) {
-    val q = Query.builder(this.accountId, counter.getAndIncrement())
+    val q = Query.builder(this.accountId, counter.getAndIncrement(), signatureBuilder)
         .getAccountTransactions(accountId, pageSize, firstHashHex, ordering)
         .buildSigned(keyPair);
 
@@ -198,7 +219,7 @@ public class QueryAPI {
                                                               String firstHashHex,
                                                               QueryBuilder.Ordering ordering) {
 
-    val q = Query.builder(this.accountId, counter.getAndIncrement())
+    val q = Query.builder(this.accountId, counter.getAndIncrement(), signatureBuilder)
         .getAccountAssetTransactions(accountId, assetId, pageSize, firstHashHex, ordering)
         .buildSigned(keyPair);
 
@@ -238,7 +259,7 @@ public class QueryAPI {
   }
 
   public TransactionsResponse getTransactions(Iterable<String> hashes) {
-    val q = Query.builder(this.accountId, counter.getAndIncrement())
+    val q = Query.builder(this.accountId, counter.getAndIncrement(), signatureBuilder)
         .getTransactions(hashes)
         .buildSigned(keyPair);
 
@@ -250,7 +271,7 @@ public class QueryAPI {
   }
 
   public AssetResponse getAssetInfo(String assetId) {
-    val q = Query.builder(this.accountId, counter.getAndIncrement())
+    val q = Query.builder(this.accountId, counter.getAndIncrement(), signatureBuilder)
         .getAssetInfo(assetId)
         .buildSigned(keyPair);
 
@@ -268,7 +289,7 @@ public class QueryAPI {
    */
   @Deprecated
   public AccountAssetResponse getAccountAssets(String accountId) {
-    val q = Query.builder(this.accountId, counter.getAndIncrement())
+    val q = Query.builder(this.accountId, counter.getAndIncrement(), signatureBuilder)
         .getAccountAssets(accountId)
         .buildSigned(keyPair);
 
@@ -284,7 +305,7 @@ public class QueryAPI {
       Integer pageSize,
       String firstAssetId
   ) {
-    val q = Query.builder(this.accountId, counter.getAndIncrement())
+    val q = Query.builder(this.accountId, counter.getAndIncrement(), signatureBuilder)
         .getAccountAssets(accountId, pageSize, firstAssetId)
         .buildSigned(keyPair);
 
@@ -303,7 +324,7 @@ public class QueryAPI {
   }
 
   public SignatoriesResponse getSignatories(String accountId) {
-    val q = Query.builder(this.accountId, counter.getAndIncrement())
+    val q = Query.builder(this.accountId, counter.getAndIncrement(), signatureBuilder)
         .getSignatories(accountId)
         .buildSigned(keyPair);
 
@@ -321,7 +342,7 @@ public class QueryAPI {
    */
   @Deprecated
   public TransactionsResponse getPendingTransactions() {
-    val q = Query.builder(this.accountId, counter.getAndIncrement())
+    val q = Query.builder(this.accountId, counter.getAndIncrement(), signatureBuilder)
         .getPendingTransactions()
         .buildSigned(keyPair);
 
@@ -337,7 +358,7 @@ public class QueryAPI {
           String firstHashHex,
           QueryBuilder.Ordering ordering
   ) {
-    val q = Query.builder(this.accountId, counter.getAndIncrement())
+    val q = Query.builder(this.accountId, counter.getAndIncrement(), signatureBuilder)
         .getPendingTransactions(pageSize, firstHashHex, ordering)
         .buildSigned(keyPair);
 
@@ -369,7 +390,7 @@ public class QueryAPI {
   }
 
   public RolesResponse getRoles() {
-    val q = Query.builder(this.accountId, counter.getAndIncrement())
+    val q = Query.builder(this.accountId, counter.getAndIncrement(), signatureBuilder)
         .getRoles()
         .buildSigned(keyPair);
 
@@ -381,7 +402,7 @@ public class QueryAPI {
   }
 
   public RolePermissionsResponse getRolePermissions(String roleId) {
-    val q = Query.builder(this.accountId, counter.getAndIncrement())
+    val q = Query.builder(this.accountId, counter.getAndIncrement(), signatureBuilder)
         .getRolePermissions(roleId)
         .buildSigned(keyPair);
 

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/QueryAPI.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/QueryAPI.java
@@ -161,10 +161,12 @@ public class QueryAPI {
     return res.getBlockResponse();
   }
 
-  public TransactionsPageResponse getAccountTransactions(String accountId, Integer pageSize,
-      String firstHashHex) {
+  public TransactionsPageResponse getAccountTransactions(String accountId,
+                                                         Integer pageSize,
+                                                         String firstHashHex,
+                                                         QueryBuilder.Ordering ordering) {
     val q = Query.builder(this.accountId, counter.getAndIncrement())
-        .getAccountTransactions(accountId, pageSize, firstHashHex)
+        .getAccountTransactions(accountId, pageSize, firstHashHex, ordering)
         .buildSigned(keyPair);
 
     val res = api.query(q);
@@ -172,16 +174,32 @@ public class QueryAPI {
     checkErrorResponse(res);
 
     return res.getTransactionsPageResponse();
+  }
+
+  public TransactionsPageResponse getAccountTransactions(String accountId,
+                                                         Integer pageSize,
+                                                         String firstHashHex) {
+    return getAccountTransactions(accountId, pageSize, firstHashHex, null);
   }
 
   public TransactionsPageResponse getAccountTransactions(String accountId, Integer pageSize) {
-    return getAccountTransactions(accountId, pageSize, null);
+    return getAccountTransactions(accountId, pageSize, null, null);
   }
 
-  public TransactionsPageResponse getAccountAssetTransactions(String accountId, String assetId,
-      Integer pageSize, String firstHashHex) {
+  public TransactionsPageResponse getAccountTransactions(String accountId,
+                                                         Integer pageSize,
+                                                         QueryBuilder.Ordering ordering) {
+    return getAccountTransactions(accountId, pageSize, null, ordering);
+  }
+
+  public TransactionsPageResponse getAccountAssetTransactions(String accountId,
+                                                              String assetId,
+                                                              Integer pageSize,
+                                                              String firstHashHex,
+                                                              QueryBuilder.Ordering ordering) {
+
     val q = Query.builder(this.accountId, counter.getAndIncrement())
-        .getAccountAssetTransactions(accountId, assetId, pageSize, firstHashHex)
+        .getAccountAssetTransactions(accountId, assetId, pageSize, firstHashHex, ordering)
         .buildSigned(keyPair);
 
     val res = api.query(q);
@@ -191,9 +209,24 @@ public class QueryAPI {
     return res.getTransactionsPageResponse();
   }
 
-  public TransactionsPageResponse getAccountAssetTransactions(String accountId, String assetId,
-      Integer pageSize) {
-    return getAccountAssetTransactions(accountId, assetId, pageSize, null);
+  public TransactionsPageResponse getAccountAssetTransactions(String accountId,
+                                                              String assetId,
+                                                              Integer pageSize,
+                                                              String firstHashHex) {
+    return getAccountAssetTransactions(accountId, assetId, pageSize, firstHashHex, null);
+  }
+
+  public TransactionsPageResponse getAccountAssetTransactions(String accountId,
+                                                              String assetId,
+                                                              Integer pageSize) {
+    return getAccountAssetTransactions(accountId, assetId, pageSize, null, null);
+  }
+
+  public TransactionsPageResponse getAccountAssetTransactions(String accountId,
+                                                              String assetId,
+                                                              Integer pageSize,
+                                                              QueryBuilder.Ordering ordering) {
+    return getAccountAssetTransactions(accountId, assetId, pageSize, null, ordering);
   }
 
   public TransactionsResponse getTransactions(List<byte[]> hashes) {
@@ -300,11 +333,12 @@ public class QueryAPI {
   }
 
   public TransactionsResponse getPendingTransactions(
-      Integer pageSize,
-      String firstHashHex
+          Integer pageSize,
+          String firstHashHex,
+          QueryBuilder.Ordering ordering
   ) {
     val q = Query.builder(this.accountId, counter.getAndIncrement())
-        .getPendingTransactions(pageSize, firstHashHex)
+        .getPendingTransactions(pageSize, firstHashHex, ordering)
         .buildSigned(keyPair);
 
     val res = api.query(q);
@@ -315,9 +349,23 @@ public class QueryAPI {
   }
 
   public TransactionsResponse getPendingTransactions(
+          Integer pageSize,
+          String firstHashHex
+  ) {
+    return getPendingTransactions(pageSize, firstHashHex, null);
+  }
+
+  public TransactionsResponse getPendingTransactions(
       Integer pageSize
   ) {
-    return getPendingTransactions(pageSize, null);
+    return getPendingTransactions(pageSize, null, null);
+  }
+
+  public TransactionsResponse getPendingTransactions(
+          Integer pageSize,
+          QueryBuilder.Ordering ordering
+  ) {
+    return getPendingTransactions(pageSize, null, ordering);
   }
 
   public RolesResponse getRoles() {

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/QueryAPI.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/QueryAPI.java
@@ -42,7 +42,7 @@ public class QueryAPI {
     this.api = api;
     this.accountId = accountId;
     this.keyPair = keyPair;
-    signatureBuilder = new Ed25519Sha3SignatureBuilder();
+    signatureBuilder = Ed25519Sha3SignatureBuilder.getInstance();
   }
 
   public QueryAPI(IrohaAPI api, String accountId, KeyPair keyPair, SignatureBuilder signatureBuilder) {
@@ -56,7 +56,7 @@ public class QueryAPI {
     this.api = api;
     this.accountId = account.getId();
     this.keyPair = account.getKeyPair();
-    signatureBuilder = new Ed25519Sha3SignatureBuilder();
+    signatureBuilder = Ed25519Sha3SignatureBuilder.getInstance();
   }
 
   public QueryAPI(IrohaAPI api, Account account, SignatureBuilder signatureBuilder) {

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/QueryAPI.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/QueryAPI.java
@@ -3,6 +3,7 @@ package jp.co.soramitsu.iroha.java;
 import iroha.protocol.QryResponses.AccountAssetResponse;
 import iroha.protocol.QryResponses.AccountDetailResponse;
 import iroha.protocol.QryResponses.AccountResponse;
+import iroha.protocol.QryResponses.EngineReceiptsResponse;
 import iroha.protocol.QryResponses.AssetResponse;
 import iroha.protocol.QryResponses.BlockResponse;
 import iroha.protocol.QryResponses.ErrorResponse;
@@ -51,6 +52,18 @@ public class QueryAPI {
       ErrorResponse errorResponse = response.getErrorResponse();
       throw new ErrorResponseException(errorResponse);
     }
+  }
+
+  public EngineReceiptsResponse getEngineReceipts(String txHash) {
+    val q = Query.builder(this.accountId, counter.getAndIncrement())
+            .getEngineReceipts(txHash)
+            .buildSigned(keyPair);
+
+    val res = api.query(q);
+
+    checkErrorResponse(res);
+
+    return res.getEngineReceiptsResponse();
   }
 
   public PeersResponse getPeers() {

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/QueryBuilder.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/QueryBuilder.java
@@ -9,6 +9,7 @@ import iroha.protocol.Queries.GetAccount;
 import iroha.protocol.Queries.GetAccountAssetTransactions;
 import iroha.protocol.Queries.GetAccountAssets;
 import iroha.protocol.Queries.GetAccountDetail;
+import iroha.protocol.Queries.GetEngineReceipts;
 import iroha.protocol.Queries.GetAccountTransactions;
 import iroha.protocol.Queries.GetAssetInfo;
 import iroha.protocol.Queries.GetBlock;
@@ -95,6 +96,18 @@ public class QueryBuilder {
   public QueryBuilder setCounter(long counter) {
     meta.setQueryCounter(counter);
     return this;
+  }
+
+  public Query getEngineReceipts(String txHash) {
+    Query query = newQuery();
+
+    query.getProto().setGetEngineReceipts(
+        GetEngineReceipts.newBuilder()
+            .setTxHash(txHash)
+            .build()
+    );
+
+    return query;
   }
 
   public Query getPeers() {

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/QueryBuilder.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/QueryBuilder.java
@@ -90,15 +90,15 @@ public class QueryBuilder {
   }
 
   public QueryBuilder(String accountId, Instant time, long counter) {
-    init(accountId, time.toEpochMilli(), counter, new Ed25519Sha3SignatureBuilder());
+    init(accountId, time.toEpochMilli(), counter, Ed25519Sha3SignatureBuilder.getInstance());
   }
 
   public QueryBuilder(String accountId, Date time, long counter) {
-    init(accountId, time.getTime(), counter, new Ed25519Sha3SignatureBuilder());
+    init(accountId, time.getTime(), counter, Ed25519Sha3SignatureBuilder.getInstance());
   }
 
   public QueryBuilder(String accountId, Long time, long counter) {
-    init(accountId, time, counter, new Ed25519Sha3SignatureBuilder());
+    init(accountId, time, counter, Ed25519Sha3SignatureBuilder.getInstance());
   }
 
   public QueryBuilder(String accountId, Instant time, long counter, SignatureBuilder signatureBuilder) {

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/QueryBuilder.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/QueryBuilder.java
@@ -31,25 +31,26 @@ import java.util.List;
 import java.util.stream.Collectors;
 import jp.co.soramitsu.iroha.java.crypto.Ed25519Sha3SignatureBuilder;
 import jp.co.soramitsu.iroha.java.crypto.SignatureBuilder;
-import lombok.Getter;
+import lombok.Value;
 import lombok.val;
 
 public class QueryBuilder {
 
   public class Ordering {
 
+    @Value
     class Sequence {
       public Sequence(Field field, Direction direction) {
         this.field = field;
         this.direction = direction;
       }
 
-      @Getter Field field;
-      @Getter Direction direction;
+      Field field;
+      Direction direction;
     }
 
     void addFieldOrdering(Field field, Direction direction) {
-      fieldOrdering.add(new Sequence(field, direction));
+      addFieldOrdering(new Sequence(field, direction));
     }
 
     void addFieldOrdering(Sequence sequence) {

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/QueryBuilder.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/QueryBuilder.java
@@ -29,6 +29,8 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Collectors;
+import jp.co.soramitsu.iroha.java.crypto.Ed25519Sha3SignatureBuilder;
+import jp.co.soramitsu.iroha.java.crypto.SignatureBuilder;
 import lombok.Getter;
 import lombok.val;
 
@@ -67,15 +69,18 @@ public class QueryBuilder {
     List<Sequence> fieldOrdering = new ArrayList<>();
   }
 
+  private SignatureBuilder signatureBuilder;
+
   private FieldValidator validator;
 
   private QueryPayloadMeta.Builder meta = QueryPayloadMeta.newBuilder();
 
   private Query newQuery() {
-    return new Query(meta);
+    return new Query(meta, signatureBuilder);
   }
 
-  private void init(String accountId, Long time, long counter) {
+  private void init(String accountId, Long time, long counter, SignatureBuilder signatureBuilder) {
+    this.signatureBuilder = signatureBuilder;
     setCreatorAccountId(accountId);
     setCreatedTime(time);
     setCounter(counter);
@@ -84,15 +89,27 @@ public class QueryBuilder {
   }
 
   public QueryBuilder(String accountId, Instant time, long counter) {
-    init(accountId, time.toEpochMilli(), counter);
+    init(accountId, time.toEpochMilli(), counter, new Ed25519Sha3SignatureBuilder());
   }
 
   public QueryBuilder(String accountId, Date time, long counter) {
-    init(accountId, time.getTime(), counter);
+    init(accountId, time.getTime(), counter, new Ed25519Sha3SignatureBuilder());
   }
 
   public QueryBuilder(String accountId, Long time, long counter) {
-    init(accountId, time, counter);
+    init(accountId, time, counter, new Ed25519Sha3SignatureBuilder());
+  }
+
+  public QueryBuilder(String accountId, Instant time, long counter, SignatureBuilder signatureBuilder) {
+    init(accountId, time.toEpochMilli(), counter, signatureBuilder);
+  }
+
+  public QueryBuilder(String accountId, Date time, long counter, SignatureBuilder signatureBuilder) {
+    init(accountId, time.getTime(), counter, signatureBuilder);
+  }
+
+  public QueryBuilder(String accountId, Long time, long counter, SignatureBuilder signatureBuilder) {
+    init(accountId, time, counter, signatureBuilder);
   }
 
   public QueryBuilder enableValidation() {

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/Transaction.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/Transaction.java
@@ -61,7 +61,7 @@ public class Transaction
   @Override
   public BuildableAndSignable<TransactionOuterClass.Transaction> sign(KeyPair keyPair) {
     updatePayload();
-    tx.addSignatures(new Ed25519Sha3SignatureBuilder().sign(this, keyPair));
+    tx.addSignatures(Ed25519Sha3SignatureBuilder.getInstance().sign(this, keyPair));
     return this;
   }
 

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/Transaction.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/Transaction.java
@@ -8,6 +8,8 @@ import iroha.protocol.TransactionOuterClass.Transaction.Payload.ReducedPayload;
 import java.security.KeyPair;
 import java.time.Instant;
 import java.util.Date;
+import jp.co.soramitsu.iroha.java.crypto.Ed25519Sha3SignatureBuilder;
+import jp.co.soramitsu.iroha.java.crypto.SignatureBuilder;
 import jp.co.soramitsu.iroha.java.detail.BuildableAndSignable;
 import jp.co.soramitsu.iroha.java.detail.Hashable;
 import jp.co.soramitsu.iroha.java.detail.ReducedHashable;
@@ -51,10 +53,22 @@ public class Transaction
     this.batchMeta = BatchMeta.newBuilder(tx.getPayload().getBatch());
   }
 
+  /**
+   * An old version of transaction sign. Uses Iroha builtin Ed25519/Sha3 signature implicitly. Prefer explicit version
+   * sign(KeyPair keyPair, SignatureBuilder signatureBuilder)
+   */
+  @Deprecated
   @Override
   public BuildableAndSignable<TransactionOuterClass.Transaction> sign(KeyPair keyPair) {
     updatePayload();
-    tx.addSignatures(Utils.sign(this, keyPair));
+    tx.addSignatures(new Ed25519Sha3SignatureBuilder().sign(this, keyPair));
+    return this;
+  }
+
+  @Override
+  public BuildableAndSignable<TransactionOuterClass.Transaction> sign(KeyPair keyPair, SignatureBuilder signatureBuilder) {
+    updatePayload();
+    tx.addSignatures(signatureBuilder.sign(this, keyPair));
     return this;
   }
 
@@ -102,5 +116,21 @@ public class Transaction
 
   public static TransactionBuilder builder(String accountId) {
     return builder(accountId, System.currentTimeMillis());
+  }
+
+  public static TransactionBuilder builder(String accountId, Long date, SignatureBuilder signatureBuilder) {
+    return new TransactionBuilder(accountId, date, signatureBuilder);
+  }
+
+  public static TransactionBuilder builder(String accountId, Date date, SignatureBuilder signatureBuilder) {
+    return new TransactionBuilder(accountId, date, signatureBuilder);
+  }
+
+  public static TransactionBuilder builder(String accountId, Instant time, SignatureBuilder signatureBuilder) {
+    return new TransactionBuilder(accountId, time, signatureBuilder);
+  }
+
+  public static TransactionBuilder builder(String accountId, SignatureBuilder signatureBuilder) {
+    return builder(accountId, System.currentTimeMillis(), signatureBuilder);
   }
 }

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/TransactionBuilder.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/TransactionBuilder.java
@@ -690,7 +690,25 @@ public class TransactionBuilder {
   }
 
   /**
-   * Compare the old value before set the new one
+   * An old version of compareAndSet. Use new one instead
+   * Compares the old value before setting the new one
+   * @param accountId - to set value in details
+   * @param key - key
+   * @param value - value to set
+   * @param optOldValue - old value to check (optional)
+   */
+  @Deprecated
+  public TransactionBuilder compareAndSetAccountDetail(
+          String accountId,
+          String key,
+          String value,
+          String optOldValue
+  ) {
+    return compareAndSetAccountDetail(accountId, key, value, optOldValue, false);
+  }
+
+  /**
+   * Compares the old value before setting the new one
    * @param accountId - to set value in details
    * @param key - key
    * @param value - value to set

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/TransactionBuilder.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/TransactionBuilder.java
@@ -695,7 +695,7 @@ public class TransactionBuilder {
    * @param key - key
    * @param value - value to set
    * @param optOldValue - old value to check (optional)
-   * @param optCheckValue - if true, empty old_value in command must match absent value in WSV;
+   * @param optCheckEmpty - if true, empty old_value in command must match absent value in WSV;
    *                        if false, any old_value in command matches absent in WSV (legacy)
    */
   public TransactionBuilder compareAndSetAccountDetail(

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/TransactionBuilder.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/TransactionBuilder.java
@@ -645,11 +645,21 @@ public class TransactionBuilder {
     return this;
   }
 
+  /**
+   * Compare the old value before set the new one
+   * @param accountId - to set value in details
+   * @param key - key
+   * @param value - value to set
+   * @param optOldValue - old value to check (optional)
+   * @param optCheckValue - if true, empty old_value in command must match absent value in WSV;
+   *                        if false, any old_value in command matches absent in WSV (legacy)
+   */
   public TransactionBuilder compareAndSetAccountDetail(
       String accountId,
       String key,
       String value,
-      String optOldValue
+      String optOldValue,
+      Boolean optCheckEmpty
   ) {
     if (nonNull(this.validator)) {
       this.validator.checkAccountId(accountId);
@@ -667,6 +677,10 @@ public class TransactionBuilder {
         this.validator.checkAccountDetailsValue(optOldValue);
       }
       b.setOldValue(optOldValue);
+    }
+
+    if (nonNull(optCheckEmpty)) {
+      b.setCheckEmpty(optCheckEmpty);
     }
 
     tx.reducedPayload.addCommands(

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/TransactionBuilder.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/TransactionBuilder.java
@@ -68,15 +68,15 @@ public class TransactionBuilder {
    * block they can be null.
    */
   public TransactionBuilder(String accountId, Instant time) {
-    init(accountId, time.toEpochMilli(), new Ed25519Sha3SignatureBuilder());
+    init(accountId, time.toEpochMilli(), Ed25519Sha3SignatureBuilder.getInstance());
   }
 
   public TransactionBuilder(String accountId, Date time) {
-    init(accountId, time.getTime(), new Ed25519Sha3SignatureBuilder());
+    init(accountId, time.getTime(), Ed25519Sha3SignatureBuilder.getInstance());
   }
 
   public TransactionBuilder(String accountId, Long time) {
-    init(accountId, time, new Ed25519Sha3SignatureBuilder());
+    init(accountId, time, Ed25519Sha3SignatureBuilder.getInstance());
   }
 
   public TransactionBuilder(String accountId, Instant time, SignatureBuilder signatureBuilder) {
@@ -93,7 +93,7 @@ public class TransactionBuilder {
 
   /* default */
   TransactionBuilder(Transaction transaction) {
-    signatureBuilder = new Ed25519Sha3SignatureBuilder();
+    signatureBuilder = Ed25519Sha3SignatureBuilder.getInstance();
     tx = transaction;
   }
 

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/TransactionBuilder.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/TransactionBuilder.java
@@ -137,8 +137,25 @@ public class TransactionBuilder {
     return this;
   }
 
+  /**
+   * Set setting value command should be used to set initialization values in genesis block only.
+   * @param key - parameter key
+   * @param value - perameter value
+   * @return Transaction builder with setSettingValue transaction
+   */
   public TransactionBuilder setSettingValue(String key, String value) {
-    throw new ValidationException(NOT_ALLOWED, "Command can be used in genesis block only");
+    tx.reducedPayload.addCommands(
+        Command.newBuilder()
+            .setSetSettingValue(
+                Commands.SetSettingValue
+                    .newBuilder()
+                    .setKey(key)
+                    .setValue(value)
+                    .build()
+            ).build()
+    );
+
+    return this;
   }
 
   public TransactionBuilder callEngine(String caller, String optCallee, String input) {

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/Utils.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/Utils.java
@@ -8,19 +8,13 @@ import iroha.protocol.BlockOuterClass.Block;
 import iroha.protocol.BlockOuterClass.Block_v1;
 import iroha.protocol.Endpoint.TxList;
 import iroha.protocol.Endpoint.TxStatusRequest;
-import iroha.protocol.Primitive;
-import iroha.protocol.Primitive.Signature;
 import iroha.protocol.Queries;
 import iroha.protocol.TransactionOuterClass;
 import iroha.protocol.TransactionOuterClass.Transaction.Payload.BatchMeta.BatchType;
-import java.security.KeyPair;
-import java.security.PrivateKey;
-import java.security.PublicKey;
+import java.security.*;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.xml.bind.DatatypeConverter;
-import jp.co.soramitsu.crypto.ed25519.Ed25519Sha3;
-import jp.co.soramitsu.iroha.java.detail.Hashable;
 import lombok.val;
 import org.spongycastle.jcajce.provider.digest.SHA3;
 
@@ -146,20 +140,6 @@ public class Utils {
     val sha3 = new SHA3.Digest256();
     val data = q.getPayload().toByteArray();
     return sha3.digest(data);
-  }
-
-  /* default */
-  static <T extends Hashable> Primitive.Signature sign(T t, KeyPair kp) {
-    byte[] rawSignature = new Ed25519Sha3().rawSign(t.hash(), kp);
-
-    return Signature.newBuilder()
-        .setSignature(
-            Utils.toHex(rawSignature)
-        )
-        .setPublicKey(
-            Utils.toHex(kp.getPublic().getEncoded())
-        )
-        .build();
   }
 
   /**

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/ValidationException.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/ValidationException.java
@@ -22,6 +22,8 @@ public class ValidationException extends IllegalArgumentException {
     ASSET_ID,
     ASSET_NAME,
     DOMAIN,
+    EVM_ADDRESS,
+    HEX_STRING,
     PUBKEY,
     PEER_ADDRESS,
     QUORUM,
@@ -32,6 +34,7 @@ public class ValidationException extends IllegalArgumentException {
     TIMESTAMP,
     DESCRIPTION,
     PAGE_SIZE,
-    HASH_LENGTH
+    HASH_LENGTH,
+    NOT_ALLOWED
   }
 }

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/crypto/Ed25519Sha2SignatureBuilder.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/crypto/Ed25519Sha2SignatureBuilder.java
@@ -1,0 +1,42 @@
+package jp.co.soramitsu.iroha.java.crypto;
+
+import iroha.protocol.Primitive;
+import jp.co.soramitsu.iroha.java.Utils;
+import jp.co.soramitsu.iroha.java.detail.Hashable;
+import net.i2p.crypto.eddsa.EdDSAEngine;
+import net.i2p.crypto.eddsa.EdDSAPublicKey;
+import net.i2p.crypto.eddsa.spec.EdDSANamedCurveTable;
+import net.i2p.crypto.eddsa.spec.EdDSAParameterSpec;
+
+import java.security.KeyPair;
+import java.security.MessageDigest;
+
+public class Ed25519Sha2SignatureBuilder implements SignatureBuilder {
+
+    @Override
+    public Primitive.Signature sign(Hashable toSign, KeyPair keyPair) {
+        try {
+            byte[] encodedHash = toSign.payload();
+
+            EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
+            // SHA-512
+            java.security.Signature sgr = new EdDSAEngine(MessageDigest.getInstance(spec.getHashAlgorithm()));
+            sgr.initSign(keyPair.getPrivate());
+
+            sgr.update(encodedHash);
+            byte[] rawSignature = sgr.sign();
+            return Primitive.Signature.newBuilder()
+                    .setSignature(Utils.toHex(rawSignature))
+                    .setPublicKey(getHexPublicKey(keyPair))
+                    .build();
+
+        } catch (Exception e) {
+            throw new CryptoException(e);
+        }
+    }
+
+    @Override
+    public String getHexPublicKey(KeyPair keyPair) {
+        return "ed0120" + Utils.toHex(((EdDSAPublicKey) keyPair.getPublic()).getAbyte());
+    }
+}

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/crypto/Ed25519Sha3SignatureBuilder.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/crypto/Ed25519Sha3SignatureBuilder.java
@@ -1,0 +1,29 @@
+package jp.co.soramitsu.iroha.java.crypto;
+
+import iroha.protocol.Primitive;
+import jp.co.soramitsu.crypto.ed25519.Ed25519Sha3;
+import jp.co.soramitsu.iroha.java.Utils;
+import jp.co.soramitsu.iroha.java.detail.Hashable;
+
+import java.security.KeyPair;
+
+/**
+ * Signs with Ed25519/Sha3
+ */
+public class Ed25519Sha3SignatureBuilder implements SignatureBuilder {
+
+    @Override
+    public Primitive.Signature sign(Hashable toSign, KeyPair keyPair) {
+        byte[] rawSignature = new Ed25519Sha3().rawSign(toSign.hash(), keyPair);
+        return Primitive.Signature.newBuilder()
+                .setSignature(Utils.toHex(rawSignature))
+                .setPublicKey(getHexPublicKey(keyPair))
+                .build();
+    }
+
+    @Override
+    public String getHexPublicKey(KeyPair keyPair) {
+        return Utils.toHex(keyPair.getPublic().getEncoded());
+    }
+
+}

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/crypto/Ed25519Sha3SignatureBuilder.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/crypto/Ed25519Sha3SignatureBuilder.java
@@ -6,24 +6,28 @@ import jp.co.soramitsu.iroha.java.Utils;
 import jp.co.soramitsu.iroha.java.detail.Hashable;
 
 import java.security.KeyPair;
+import lombok.Getter;
 
 /**
  * Signs with Ed25519/Sha3
  */
 public class Ed25519Sha3SignatureBuilder implements SignatureBuilder {
 
-    @Override
-    public Primitive.Signature sign(Hashable toSign, KeyPair keyPair) {
-        byte[] rawSignature = new Ed25519Sha3().rawSign(toSign.hash(), keyPair);
-        return Primitive.Signature.newBuilder()
-                .setSignature(Utils.toHex(rawSignature))
-                .setPublicKey(getHexPublicKey(keyPair))
-                .build();
-    }
+  @Getter
+  private static final Ed25519Sha3SignatureBuilder instance = new Ed25519Sha3SignatureBuilder();
 
-    @Override
-    public String getHexPublicKey(KeyPair keyPair) {
-        return Utils.toHex(keyPair.getPublic().getEncoded());
-    }
+  @Override
+  public Primitive.Signature sign(Hashable toSign, KeyPair keyPair) {
+    byte[] rawSignature = new Ed25519Sha3().rawSign(toSign.hash(), keyPair);
+    return Primitive.Signature.newBuilder()
+        .setSignature(Utils.toHex(rawSignature))
+        .setPublicKey(getHexPublicKey(keyPair))
+        .build();
+  }
+
+  @Override
+  public String getHexPublicKey(KeyPair keyPair) {
+    return Utils.toHex(keyPair.getPublic().getEncoded());
+  }
 
 }

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/crypto/SignatureBuilder.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/crypto/SignatureBuilder.java
@@ -1,0 +1,18 @@
+package jp.co.soramitsu.iroha.java.crypto;
+
+import iroha.protocol.Primitive;
+import jp.co.soramitsu.iroha.java.detail.Hashable;
+
+import java.security.KeyPair;
+
+public interface SignatureBuilder {
+    Primitive.Signature sign(Hashable toSign, KeyPair keyPair);
+
+    String getHexPublicKey(KeyPair keyPair);
+
+    class CryptoException extends RuntimeException {
+        CryptoException(Exception e) {
+            super(e);
+        }
+    }
+}

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/debug/Account.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/debug/Account.java
@@ -1,18 +1,45 @@
 package jp.co.soramitsu.iroha.java.debug;
 
-import java.security.KeyPair;
+import java.security.*;
 import jp.co.soramitsu.crypto.ed25519.Ed25519Sha3;
+import jp.co.soramitsu.iroha.java.Utils;
 import lombok.Value;
+import net.i2p.crypto.eddsa.EdDSAPrivateKey;
+import net.i2p.crypto.eddsa.EdDSAPublicKey;
+import net.i2p.crypto.eddsa.spec.*;
+import static javax.xml.bind.DatatypeConverter.parseHexBinary;
+import static jp.co.soramitsu.crypto.ed25519.spec.EdDSANamedCurveTable.ED_25519;
 
 @Value
 public class Account {
 
-  private static Ed25519Sha3 crypto = new Ed25519Sha3();
+  private static Ed25519Sha3 edSha3Crypto = new Ed25519Sha3();
 
   private String id;
   private KeyPair keyPair;
 
+  public KeyPair getKeyPair() {
+    return keyPair;
+  }
+
   public static Account create(String id) {
-    return new Account(id, crypto.generateKeypair());
+    return new Account(id, edSha3Crypto.generateKeypair());
+  }
+
+  public static Account createWithEd25519Sha2(String id) {
+    byte[] pkb = parseHexBinary("99fe8969acdafb09bfdd0046370e2fa2580b0c2591a2363625250da14d771b63");
+    EdDSAParameterSpec spec = EdDSANamedCurveTable.getByName(ED_25519);
+    net.i2p.crypto.eddsa.EdDSAPrivateKey pk = new EdDSAPrivateKey(new EdDSAPrivateKeySpec(pkb, spec));
+    EdDSANamedCurveSpec keySpecs = EdDSANamedCurveTable.getByName(EdDSANamedCurveTable.ED_25519);
+    EdDSAPublicKeySpec pubKey = new EdDSAPublicKeySpec(pk.getA(), keySpecs);
+    KeyPair kp = new KeyPair(new EdDSAPublicKey(pubKey), pk);
+
+    return new Account(id, kp);
+  }
+
+  public String getHexPublicKey() {
+    if (keyPair.getPublic() instanceof EdDSAPublicKey)
+      return "ed0120" + Utils.toHex(((EdDSAPublicKey) keyPair.getPublic()).getAbyte());
+    return Utils.toHex(keyPair.getPublic().getEncoded());
   }
 }

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/detail/BuildableAndSignable.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/detail/BuildableAndSignable.java
@@ -2,10 +2,18 @@ package jp.co.soramitsu.iroha.java.detail;
 
 import java.security.KeyPair;
 import jp.co.soramitsu.crypto.ed25519.Ed25519Sha3.CryptoException;
+import jp.co.soramitsu.iroha.java.crypto.SignatureBuilder;
 
 public interface BuildableAndSignable<T> {
 
+  /**
+   * An old version of transaction sign. Uses Iroha builtin Ed25519/Sha3 signature implicitly. Prefer explicit version
+   * sign(KeyPair keyPair, SignatureBuilder signatureBuilder)
+   */
+  @Deprecated
   BuildableAndSignable<T> sign(KeyPair keyPair) throws CryptoException;
+
+  BuildableAndSignable<T> sign(KeyPair keyPair, SignatureBuilder signatureBuilder) throws CryptoException;
 
   T build();
 }

--- a/client/src/main/java/jp/co/soramitsu/iroha/java/detail/Const.java
+++ b/client/src/main/java/jp/co/soramitsu/iroha/java/detail/Const.java
@@ -14,4 +14,9 @@ public class Const {
   public static final Pattern roleNamePattern = Pattern.compile("[a-z_0-9]{1,32}");
   public static final Pattern assetNamePattern = Pattern.compile("[a-z_0-9]{1,32}");
 
+  /** EVM address is a 20-bytes string in hex representation (40 symbols) */
+  public static final Pattern evmAddress = Pattern.compile("[0-9a-fA-F]{40}");
+
+  /** Hex string of any length */
+  public static final Pattern hexString = Pattern.compile("[0-9a-fA-F]*");
 }

--- a/client/src/main/proto/block.proto
+++ b/client/src/main/proto/block.proto
@@ -5,6 +5,9 @@
 
 syntax = "proto3";
 package iroha.protocol;
+
+option go_package = "iroha.generated/protocol";
+
 import "primitive.proto";
 import "transaction.proto";
 

--- a/client/src/main/proto/commands.proto
+++ b/client/src/main/proto/commands.proto
@@ -106,6 +106,7 @@ message CompareAndSetAccountDetail {
     oneof opt_old_value {
         string old_value = 4;
     }
+    bool check_empty = 5;
 }
 
 message SetSettingValue {

--- a/client/src/main/proto/commands.proto
+++ b/client/src/main/proto/commands.proto
@@ -5,6 +5,9 @@
 
 syntax = "proto3";
 package iroha.protocol;
+
+option go_package = "iroha.generated/protocol";
+
 import "primitive.proto";
 
 message AddAssetQuantity {
@@ -17,7 +20,7 @@ message AddPeer {
 }
 
 message RemovePeer {
-    string public_key = 1; // hex string
+    string public_key = 1;  // hex string
 }
 
 message AddSignatory {
@@ -96,13 +99,36 @@ message SubtractAssetQuantity {
     string amount = 2;
 }
 
-message CompareAndSetAccountDetail{
+message CompareAndSetAccountDetail {
     string account_id = 1;
     string key = 2;
     string value = 3;
     oneof opt_old_value {
         string old_value = 4;
     }
+}
+
+message SetSettingValue {
+    string key = 1;
+    string value = 2;
+}
+
+message CallEngine {
+    enum EngineType {
+      kSolidity = 0;
+    }
+    EngineType type = 1;
+    string caller = 2;
+    oneof opt_callee {
+      string callee = 3;  // hex string
+    }
+    string input = 4;  // hex string
+}
+
+message CallModel{
+    message Payload {}
+    Payload payload = 1;
+    DataModelId dm_id = 2;
 }
 
 message Command {
@@ -125,5 +151,8 @@ message Command {
         TransferAsset transfer_asset = 16;
         RemovePeer remove_peer = 17;
         CompareAndSetAccountDetail compare_and_set_account_detail = 18;
+        SetSettingValue set_setting_value = 19;
+        CallEngine call_engine = 20;
+        CallModel call_model = 21;
     }
 }

--- a/client/src/main/proto/endpoint.proto
+++ b/client/src/main/proto/endpoint.proto
@@ -7,6 +7,8 @@ syntax = "proto3";
 
 package iroha.protocol;
 
+option go_package = "iroha.generated/protocol";
+
 import "transaction.proto";
 import "queries.proto";
 import "qry_responses.proto";

--- a/client/src/main/proto/primitive.proto
+++ b/client/src/main/proto/primitive.proto
@@ -11,9 +11,9 @@
 
 syntax = "proto3";
 
-
 package iroha.protocol;
 
+option go_package = "iroha.generated/protocol";
 
 /**
  * Represents any possible value for permission field,
@@ -46,6 +46,8 @@ enum RolePermission {
   can_create_domain = 14;
   can_add_domain_asset_qty = 43;
   can_subtract_domain_asset_qty = 44;
+  can_call_engine = 48;
+  can_call_model = 53;
 
   // Query permissions
   can_read_assets = 15;
@@ -72,6 +74,9 @@ enum RolePermission {
   can_get_all_txs = 36;
   can_get_blocks = 42;
   can_get_peers = 45;
+  can_get_my_engine_receipts = 50;
+  can_get_domain_engine_receipts = 51;
+  can_get_all_engine_receipts = 52;
 
   // Grant permissions
   can_grant_can_set_my_quorum = 37;
@@ -79,6 +84,10 @@ enum RolePermission {
   can_grant_can_remove_my_signatory = 39;
   can_grant_can_transfer_my_assets = 40;
   can_grant_can_set_my_account_detail = 41;
+  can_grant_can_call_engine_on_my_behalf = 49;
+
+  // Root Permission
+  root = 47;
 }
 
 enum GrantablePermission {
@@ -86,20 +95,52 @@ enum GrantablePermission {
   can_remove_my_signatory = 1;
   can_set_my_quorum = 2;
   can_set_my_account_detail = 3;
-  can_transfer_my_assets = 4; // not implemented now
+  can_transfer_my_assets = 4;  // not implemented now
+  can_call_engine_on_my_behalf = 5;
 }
 
 message Signature {
   string public_key = 1;
-  string signature  = 2;
+  string signature = 2;
 }
 
 message Peer {
   string address = 1;
-  string peer_key = 2; // hex string
+  string peer_key = 2;  // hex string
+  oneof certificate {
+    string tls_certificate = 3;  // pem-encoded string
+  }
 }
 
 message AccountDetailRecordId {
   string writer = 1;
   string key = 2;
 }
+
+message EngineLog {
+  string address = 1;   // hex string
+  string data = 2;      // hex string
+  repeated string topics = 3; // hex string
+}
+
+message CallResult {
+  string callee = 1;
+  string result_data = 2;
+}
+
+message EngineReceipt {
+  int32 command_index = 1;
+  string caller = 2;
+  oneof result_or_contract_address {
+    CallResult call_result = 3;
+    string contract_address = 4;
+  }
+  repeated EngineLog logs = 5;
+}
+
+message DataModelId {
+    string name = 1;
+    string version = 2;
+}
+
+

--- a/client/src/main/proto/proposal.proto
+++ b/client/src/main/proto/proposal.proto
@@ -6,6 +6,8 @@
 syntax = "proto3";
 package iroha.protocol;
 
+option go_package = "iroha.generated/protocol";
+
 import "transaction.proto";
 
 message Proposal {

--- a/client/src/main/proto/qry_responses.proto
+++ b/client/src/main/proto/qry_responses.proto
@@ -5,6 +5,9 @@
 
 syntax = "proto3";
 package iroha.protocol;
+
+option go_package = "iroha.generated/protocol";
+
 import "block.proto";
 import "transaction.proto";
 import "primitive.proto";
@@ -113,6 +116,10 @@ message PeersResponse {
   repeated Peer peers = 1;
 }
 
+message EngineReceiptsResponse {
+  repeated EngineReceipt engine_receipts = 1;
+}
+
 message QueryResponse {
   oneof response {
     AccountAssetResponse account_assets_response = 1;
@@ -128,6 +135,7 @@ message QueryResponse {
     PendingTransactionsPageResponse pending_transactions_page_response = 13;
     BlockResponse block_response = 12;
     PeersResponse peers_response = 14;
+    EngineReceiptsResponse engine_receipts_response = 15;
   }
   string query_hash = 10;
 }

--- a/client/src/main/proto/queries.proto
+++ b/client/src/main/proto/queries.proto
@@ -6,13 +6,34 @@
 syntax = "proto3";
 package iroha.protocol;
 
+option go_package = "iroha.generated/protocol";
+
 import "primitive.proto";
+
+enum Field {
+  kCreatedTime = 0;
+  kPosition = 1;
+}
+
+enum Direction {
+  kAscending = 0;
+  kDescending = 1;
+}
+
+message Ordering {
+  message FieldOrdering {
+    Field field = 1;
+    Direction direction = 2;
+  }
+  repeated FieldOrdering sequence = 1;
+}
 
 message TxPaginationMeta {
   uint32 page_size = 1;
   oneof opt_first_tx_hash {
     string first_tx_hash = 2;
   }
+  Ordering ordering = 3;
 }
 
 message AssetPaginationMeta {
@@ -99,6 +120,10 @@ message QueryPayloadMeta {
   uint64 query_counter = 3;
 }
 
+message GetEngineReceipts {
+  string tx_hash = 1;
+}
+
 
 message Query {
   message Payload {
@@ -117,6 +142,7 @@ message Query {
       GetPendingTransactions get_pending_transactions = 13;
       GetBlock get_block = 14;
       GetPeers get_peers = 15;
+      GetEngineReceipts get_engine_receipts = 16;
     }
   }
 

--- a/client/src/main/proto/transaction.proto
+++ b/client/src/main/proto/transaction.proto
@@ -5,6 +5,9 @@
 
 syntax = "proto3";
 package iroha.protocol;
+
+option go_package = "iroha.generated/protocol";
+
 import "commands.proto";
 import "primitive.proto";
 

--- a/client/src/test/groovy/jp/co/soramitsu/iroha/java/CommandsTest.groovy
+++ b/client/src/test/groovy/jp/co/soramitsu/iroha/java/CommandsTest.groovy
@@ -1,6 +1,7 @@
 package jp.co.soramitsu.iroha.java
 
 import jp.co.soramitsu.iroha.java.debug.Account
+import jp.co.soramitsu.iroha.java.debug.TestTransactionStatusObserver
 import jp.co.soramitsu.iroha.testcontainers.IrohaContainer
 import jp.co.soramitsu.iroha.testcontainers.PeerConfig
 import jp.co.soramitsu.iroha.testcontainers.detail.GenesisBlockBuilder
@@ -10,6 +11,7 @@ import spock.lang.Unroll
 import static jp.co.soramitsu.iroha.java.Transaction.builder
 import static jp.co.soramitsu.iroha.testcontainers.detail.GenesisBlockBuilder.defaultAccountId
 import static jp.co.soramitsu.iroha.testcontainers.detail.GenesisBlockBuilder.defaultKeyPair
+import static jp.co.soramitsu.iroha.java.ValidationException.Type.NOT_ALLOWED;
 
 class CommandsTest extends Specification {
 
@@ -54,6 +56,23 @@ class CommandsTest extends Specification {
                 .build()
     }
 
+    /**
+     * Binary code of contract
+     */
+    static def evm_binary_code = "606060405260a18060106000396000f360606040526000357c01000000000000000" +
+            "0000000000000000000000000000000000000000090048063d46300fd1460435780" +
+            "63ee919d5014606857603f565b6002565b34600257605260048050506082565b604" +
+            "0518082815260200191505060405180910390f35b34600257608060048080359060" +
+            "200190919050506093565b005b600060006000505490506090565b90565b8060006" +
+            "00050819055505b5056"
+
+    /**
+     * calling setA(uint256), bytes4(keccak256(setA(uint256))) == ee919d50, and
+     * append uint256 equal to 1 as the parameter
+     */
+    static def evm_abi_encoded_call = "ee919d50" +
+            "0000000000000000000000000000000000000000000000000000000000000001"
+
     @Unroll
     def "compareAndSet command: key=#key, value=#value, oldValue=#oldValue"() {
         given:
@@ -64,11 +83,13 @@ class CommandsTest extends Specification {
                 .compareAndSetAccountDetail(account.getId(), key, value, oldValue)
                 .sign(account.keyPair)
                 .build()
-        api.transaction(tx).blockingSubscribe()
+        def transaction_observer = new TestTransactionStatusObserver()
+        api.transaction(tx).blockingSubscribe(transaction_observer)
 
         def actual_value = qapi.getAccountDetails(account.getId(), account.getId(), key, 1).getDetail()
 
         then:
+        transaction_observer.assertAllTransactionsCommitted()
         actual_value == expected_value
 
         where:
@@ -76,8 +97,99 @@ class CommandsTest extends Specification {
         "initial_key1" | "updated_val" | "wrong_val"   | "{ \"a@test\" : { \"initial_key1\" : \"initial_val\" } }"
         "initial_key1" | "updated_val" | null          | "{ \"a@test\" : { \"initial_key1\" : \"initial_val\" } }"
         "initial_key2" | "updated_val" | "initial_val" | "{ \"a@test\" : { \"initial_key2\" : \"updated_val\" } }"
-        // Seems to be failed in Iroha
-        //"empty1"       | "value"       | "wrong"       | "{}"
+        "empty1"       | "value"       | "wrong"       | "{}"
         "empty2"       | "value"       | null          | "{ \"a@test\" : { \"empty2\" : \"value\" } }"
+    }
+
+    @Unroll
+    def "callEngine command deploy contract: caller=#caller, input=input"() {
+        given:
+        def qapi = new QueryAPI(api, account)
+
+        when:
+        def tx = Transaction.builder(account.getId())
+                .callEngine(caller, null, input)
+                .sign(account.keyPair)
+                .build()
+        def hash = Utils.hash(tx);
+        def transaction_observer = new TestTransactionStatusObserver()
+        api.transaction(tx).blockingSubscribe(transaction_observer)
+
+        // TODO (a.chernyshov) remove lower case as soon as Iroha supports case insensitive hash comparison
+        def actual_value = qapi.getEngineReceipts(Utils.toHex(hash).toLowerCase())
+
+        then:
+        transaction_observer.assertAllTransactionsCommitted()
+
+        actual_value.getEngineReceiptsCount() == 1
+        def receipt = actual_value.getEngineReceipts(0)
+        receipt.getCommandIndex() == 0
+        receipt.getCaller() == account.getId()
+        !receipt.getContractAddress().empty
+        receipt.getCallResult().getCallee().empty
+        receipt.getCallResult().getResultData().empty
+
+        where:
+        caller          | input
+        account.getId() | evm_binary_code
+        account.getId() | ""
+    }
+
+    @Unroll
+    def "callEngine command call contract: caller=#caller, input=input"() {
+        given:
+        def qapi = new QueryAPI(api, account)
+
+        // deploy contract
+        def deploy_tx = Transaction.builder(account.getId())
+                .callEngine(account.getId(), null, evm_binary_code)
+                .sign(account.keyPair)
+                .build()
+        def deploy_hash = Utils.hash(deploy_tx);
+        api.transaction(deploy_tx).blockingSubscribe()
+        // TODO (a.chernyshov) remove lower case as soon as Iroha supports case insensitive hash comparison
+        def deploy_receipt = qapi.getEngineReceipts(Utils.toHex(deploy_hash).toLowerCase())
+        def callee = deploy_receipt.getEngineReceipts(0).contractAddress
+
+        when:
+        def tx = Transaction.builder(account.getId())
+                .callEngine(caller, callee, input)
+                .sign(account.keyPair)
+                .build()
+        def hash = Utils.hash(tx);
+        def transaction_observer = new TestTransactionStatusObserver()
+        api.transaction(tx).blockingSubscribe(transaction_observer)
+
+        // TODO (a.chernyshov) remove lower case as soon as Iroha supports case insensitive hash comparison
+        def actual_value = qapi.getEngineReceipts(Utils.toHex(hash).toLowerCase())
+
+        then:
+        transaction_observer.assertAllTransactionsCommitted()
+
+        actual_value.getEngineReceiptsCount() == 1
+        def receipt = actual_value.getEngineReceipts(0)
+        receipt.getCommandIndex() == 0
+        receipt.getCaller() == account.getId()
+        receipt.getContractAddress().empty
+        receipt.getCallResult().getCallee() == callee
+        receipt.getCallResult().getResultData().empty
+
+        where:
+        caller          | input
+        account.getId() | evm_abi_encoded_call
+    }
+
+    @Unroll
+    def "setSettingValue command throws NOT_ALLOWED: key=#key, value=#value"() {
+        when:
+        Transaction.builder(account.getId())
+                .setSettingValue(key, value)
+        then:
+        def e = thrown(ValidationException.class)
+        e.type == NOT_ALLOWED
+
+        where:
+        key       | value
+        "any key" | "any value"
     }
 }

--- a/client/src/test/groovy/jp/co/soramitsu/iroha/java/CommandsTest.groovy
+++ b/client/src/test/groovy/jp/co/soramitsu/iroha/java/CommandsTest.groovy
@@ -58,6 +58,7 @@ class CommandsTest extends Specification {
 
     /**
      * Binary code of contract
+     * Just a valid binary code.
      */
     static def evm_binary_code = "606060405260a18060106000396000f360606040526000357c01000000000000000" +
             "0000000000000000000000000000000000000000090048063d46300fd1460435780" +

--- a/client/src/test/groovy/jp/co/soramitsu/iroha/java/CommandsTest.groovy
+++ b/client/src/test/groovy/jp/co/soramitsu/iroha/java/CommandsTest.groovy
@@ -11,7 +11,6 @@ import spock.lang.Unroll
 import static jp.co.soramitsu.iroha.java.Transaction.builder
 import static jp.co.soramitsu.iroha.testcontainers.detail.GenesisBlockBuilder.defaultAccountId
 import static jp.co.soramitsu.iroha.testcontainers.detail.GenesisBlockBuilder.defaultKeyPair
-import static jp.co.soramitsu.iroha.java.ValidationException.Type.NOT_ALLOWED;
 
 class CommandsTest extends Specification {
 
@@ -183,19 +182,5 @@ class CommandsTest extends Specification {
         where:
         caller          | input
         account.getId() | evm_abi_encoded_call
-    }
-
-    @Unroll
-    def "setSettingValue command throws NOT_ALLOWED: key=#key, value=#value"() {
-        when:
-        Transaction.builder(account.getId())
-                .setSettingValue(key, value)
-        then:
-        def e = thrown(ValidationException.class)
-        e.type == NOT_ALLOWED
-
-        where:
-        key       | value
-        "any key" | "any value"
     }
 }

--- a/client/src/test/groovy/jp/co/soramitsu/iroha/java/Ed25519Sha2Test.groovy
+++ b/client/src/test/groovy/jp/co/soramitsu/iroha/java/Ed25519Sha2Test.groovy
@@ -1,0 +1,102 @@
+package jp.co.soramitsu.iroha.java
+
+import jp.co.soramitsu.iroha.java.crypto.Ed25519Sha2SignatureBuilder
+import jp.co.soramitsu.iroha.java.crypto.Ed25519Sha3SignatureBuilder
+import jp.co.soramitsu.iroha.java.debug.Account
+import jp.co.soramitsu.iroha.java.debug.TestTransactionStatusObserver
+import jp.co.soramitsu.iroha.testcontainers.IrohaContainer
+import jp.co.soramitsu.iroha.testcontainers.PeerConfig
+import jp.co.soramitsu.iroha.testcontainers.detail.GenesisBlockBuilder
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static jp.co.soramitsu.iroha.testcontainers.detail.GenesisBlockBuilder.defaultAccountId
+import static jp.co.soramitsu.iroha.testcontainers.detail.GenesisBlockBuilder.defaultDomainName
+import static jp.co.soramitsu.iroha.testcontainers.detail.GenesisBlockBuilder.defaultKeyPair
+
+class Ed25519Sha2Test extends Specification {
+
+    static Account account = Account.createWithEd25519Sha2("a@test")
+
+    static IrohaAPI api
+    static def iroha = new IrohaContainer()
+            .withPeerConfig(
+                    PeerConfig.builder()
+                            .genesisBlock(getGenesisBlock())
+                            .build())
+
+    def setupSpec() {
+        iroha.start()
+        api = iroha.getApi()
+    }
+
+    def cleanupSpec() {
+        iroha.stop()
+    }
+
+    static def createAccount(Account a) {
+        return Transaction.builder(defaultAccountId)
+                .createAccount("a", defaultDomainName, a.getHexPublicKey())
+                .sign(defaultKeyPair)
+                .build()
+    }
+
+    static def getGenesisBlock() {
+        return new GenesisBlockBuilder()
+                .addDefaultTransaction()
+                .build()
+    }
+
+    @Unroll
+    def "setAccountDetail and getAccountDetail by Ed25519 crypto"() {
+        given:
+        def qapi = new QueryAPI(api, account, new Ed25519Sha2SignatureBuilder())
+
+        when: "send tx with Iroha builtin Ed25519/Sha3 with default builder without specifying SignatureBuilder"
+        def tx = Transaction.builder(defaultAccountId, )
+                .setAccountDetail(defaultAccountId, "key", "value")
+                .sign(defaultKeyPair)
+                .build()
+        def transaction_observer = new TestTransactionStatusObserver()
+        api.transaction(tx).blockingSubscribe(transaction_observer)
+
+        then:
+        transaction_observer.assertAllTransactionsCommitted()
+
+        when: "create account with Ed25519/Sha2 pubkey"
+        tx = Transaction.builder(defaultAccountId, new Ed25519Sha3SignatureBuilder())
+                .createAccount("a", defaultDomainName, account.getHexPublicKey())
+                .sign(defaultKeyPair)
+                .build()
+        transaction_observer = new TestTransactionStatusObserver()
+        api.transaction(tx).blockingSubscribe(transaction_observer)
+
+        then:
+        transaction_observer.assertAllTransactionsCommitted()
+
+        when: "send tx from account with Ed25519/Sha2 pubkey"
+        tx = Transaction.builder(account.getId(), new Ed25519Sha2SignatureBuilder())
+                .setAccountDetail(account.getId(), "key", "value")
+                .sign(account.keyPair)
+                .build()
+        transaction_observer = new TestTransactionStatusObserver()
+        api.transaction(tx).blockingSubscribe(transaction_observer)
+
+        then:
+        transaction_observer.assertAllTransactionsCommitted()
+
+        when: "query with Ed25519/Sha3 as default SignatureBuilder"
+        def defaultQueryApi = new QueryAPI(api, defaultAccountId, defaultKeyPair)
+        def actual_value = defaultQueryApi.getAccountDetails(account.getId(), account.getId(), "key", 1).getDetail()
+
+        then:
+        actual_value == "{ \"a@test\" : { \"key\" : \"value\" } }"
+
+        when: "query with Ed25519/Sha2"
+        actual_value = qapi.getAccountDetails(account.getId(), account.getId(), "key", 1).getDetail()
+
+        then:
+        actual_value == "{ \"a@test\" : { \"key\" : \"value\" } }"
+    }
+
+}

--- a/client/src/test/groovy/jp/co/soramitsu/iroha/java/FieldValidatorTest.groovy
+++ b/client/src/test/groovy/jp/co/soramitsu/iroha/java/FieldValidatorTest.groovy
@@ -33,6 +33,9 @@ class FieldValidatorTest extends Specification {
         fv.checkRoleName(role)
         fv.checkTimestamp(time)
         fv.checkDescription(description)
+        fv.checkEvmAddress(evmAddress)
+        fv.checkHexString(hexString)
+        fv.checkHexString(emptyHexString)
 
         then:
         noExceptionThrown()
@@ -51,6 +54,9 @@ class FieldValidatorTest extends Specification {
         publicKey = new Ed25519Sha3().generateKeypair().getPublic().getEncoded()
         time = Instant.now().toEpochMilli()
         description = "description"
+        evmAddress = "7C370993FD90AF204FD582004E2E54E6A94F2651"
+        hexString = "DEADface"
+        emptyHexString = ""
     }
 
     def "invalid account is invalid"() {
@@ -70,6 +76,12 @@ class FieldValidatorTest extends Specification {
                 break
             case AMOUNT:
                 fv.checkAmount(string as String)
+                break
+            case EVM_ADDRESS:
+                fv.checkEvmAddress(string as String)
+                break
+            case HEX_STRING:
+                fv.checkHexString(string as String)
                 break
             case PUBKEY:
                 fv.checkPublicKey(string as byte[])
@@ -124,6 +136,10 @@ class FieldValidatorTest extends Specification {
         AMOUNT        | "hello.123"  // number format exception
         AMOUNT        | BigDecimal.TEN.setScale(300).toString() // does not fit in uint256
         AMOUNT        | BigDecimal.ONE.negate().toString() // negative
+        EVM_ADDRESS   | "7C370993FD90AF204" // too short
+        EVM_ADDRESS   | "7C370993FD90AF204FD582004E2E54E6A94F26517C370993FD90AF204FD582004E2E54E6A94F2651" // too long
+        EVM_ADDRESS   | "wrong symbols" // wrong symbols
+        HEX_STRING    | "wrong symbols" // wrong symbols
         PUBKEY        | [1, 2, 3] as byte[] // wrong size
         PEER_ADDRESS  | "127.0.0.1" // no port
         PEER_ADDRESS  | "127.0.0.1:100a" // wrong port

--- a/client/src/test/groovy/jp/co/soramitsu/iroha/java/QueryApiTest.groovy
+++ b/client/src/test/groovy/jp/co/soramitsu/iroha/java/QueryApiTest.groovy
@@ -11,7 +11,7 @@ import static jp.co.soramitsu.iroha.java.Transaction.builder
 import static jp.co.soramitsu.iroha.testcontainers.detail.GenesisBlockBuilder.defaultAccountId
 import static jp.co.soramitsu.iroha.testcontainers.detail.GenesisBlockBuilder.defaultKeyPair
 import static jp.co.soramitsu.iroha.testcontainers.detail.GenesisBlockBuilder.defaultRoleName
-import static jp.co.soramitsu.iroha.testcontainers.detail.GenesisBlockBuilder.TOTAL_PERMISSIONS_NUMBER
+import static jp.co.soramitsu.iroha.testcontainers.detail.GenesisBlockBuilder.MAX_PERMISSION_NUMBER
 
 class QueryApiTest extends Specification {
 
@@ -107,7 +107,7 @@ class QueryApiTest extends Specification {
       def response = qapi.getRolePermissions(defaultRoleName)
 
       then:
-      response.getPermissionsCount() == TOTAL_PERMISSIONS_NUMBER + 1
+      response.getPermissionsCount() == MAX_PERMISSION_NUMBER
     }
 
     @Unroll

--- a/client/src/test/groovy/jp/co/soramitsu/iroha/java/query/GetAccountTransactions.groovy
+++ b/client/src/test/groovy/jp/co/soramitsu/iroha/java/query/GetAccountTransactions.groovy
@@ -1,0 +1,119 @@
+package jp.co.soramitsu.iroha.java.query
+
+import iroha.protocol.Queries
+import jp.co.soramitsu.iroha.java.*
+import jp.co.soramitsu.iroha.java.debug.Account
+import jp.co.soramitsu.iroha.testcontainers.IrohaContainer
+import jp.co.soramitsu.iroha.testcontainers.PeerConfig
+import jp.co.soramitsu.iroha.testcontainers.detail.GenesisBlockBuilder
+import spock.lang.Specification
+import spock.lang.Unroll
+
+import static jp.co.soramitsu.iroha.java.Transaction.builder
+import static jp.co.soramitsu.iroha.testcontainers.detail.GenesisBlockBuilder.defaultKeyPair
+
+class GetAccountTransactions extends Specification {
+
+    static final def defaultAccount = "test"
+    static final def defaultDomain = "test"
+    static final def defaultAccountId = String.format("%s@%s", defaultAccount, defaultDomain)
+    static Account A = Account.create("a@test")
+    static Date now = new Date()
+    static tx1 = setDetail(A, "key1", "Avalue1", now.getTime() + 1)
+    static tx2 = setDetail(A, "key2", "Avalue2", now.getTime() + 2)
+    static tx3 = setDetail(A, "key3", "Avalue3", now.getTime() + 1)
+    static tx4 = setDetail(A, "key4", "Avalue4", now.getTime() + 2)
+
+    static IrohaAPI api
+    static def iroha = new IrohaContainer()
+            .withPeerConfig(
+                    PeerConfig.builder()
+                            .genesisBlock(getGenesisBlock())
+                            .build())
+
+    def setupSpec() {
+        iroha.start()
+        api = iroha.getApi()
+    }
+
+    def cleanupSpec() {
+        iroha.stop()
+    }
+
+    static def createAccount(Account a) {
+        return builder(defaultAccountId)
+                .createAccount(a.id, a.keyPair.public)
+                .sign(defaultKeyPair)
+                .build()
+    }
+
+    static def setDetail(Account account, String key, String value, Long createdTime) {
+        return builder(account.id)
+                .setAccountDetail(account.id, key, value)
+                .setCreatedTime(createdTime)
+                .sign(account.keyPair)
+                .build()
+    }
+
+    static def getGenesisBlock() {
+        return new GenesisBlockBuilder()
+                .addDefaultTransaction()
+                .addTransaction(createAccount(A))
+                .addTransaction(tx1)
+                .addTransaction(tx2)
+                .addTransaction(tx3)
+                .addTransaction(tx4)
+                .build()
+    }
+
+    @Unroll
+    def "getAccountTransactions"() {
+        given:
+        def qapi = new QueryAPI(api, A)
+
+        when: "get account transactions without ordering returns txs in order of creation (tx1, tx2, tx3, tx4)"
+        def response = qapi.getAccountTransactions(A.id, 100)
+
+        then:
+        response.transactionsCount == 4
+        response.transactionsList.get(0) == tx1
+        response.transactionsList.get(1) == tx2
+        response.transactionsList.get(2) == tx3
+        response.transactionsList.get(3) == tx4
+
+        when: "get account transactions without empty ordering returns txs in order of creation (tx1, tx2, tx3, tx4)"
+        QueryBuilder.Ordering ordering = new QueryBuilder.Ordering()
+        response = qapi.getAccountTransactions(A.id, 100, ordering)
+
+        then:
+        response.transactionsCount == 4
+        response.transactionsList.get(0) == tx1
+        response.transactionsList.get(1) == tx2
+        response.transactionsList.get(2) == tx3
+        response.transactionsList.get(3) == tx4
+
+        when: "get account transactions with time ordering returns txs ordered by time (tx1, tx3, tx2, tx4)"
+        ordering = new QueryBuilder.Ordering()
+        ordering.addFieldOrdering(Queries.Field.kCreatedTime, Queries.Direction.kAscending)
+        response = qapi.getAccountTransactions(A.id, 100, ordering)
+
+        then:
+        response.transactionsCount == 4
+        response.transactionsList.get(0) == tx1
+        response.transactionsList.get(1) == tx3
+        response.transactionsList.get(2) == tx2
+        response.transactionsList.get(3) == tx4
+
+        when: "get account transactions with descending time ordering returns txs ordered by time (tx2, tx4, tx1, tx3)"
+        ordering = new QueryBuilder.Ordering()
+        ordering.addFieldOrdering(Queries.Field.kCreatedTime, Queries.Direction.kDescending)
+        response = qapi.getAccountTransactions(A.id, 100, ordering)
+
+        then:
+        response.transactionsCount == 4
+        response.transactionsList.get(0) == tx2
+        response.transactionsList.get(1) == tx4
+        response.transactionsList.get(2) == tx1
+        response.transactionsList.get(3) == tx3
+    }
+}

--- a/client/src/test/groovy/jp/co/soramitsu/iroha/java/query/QueryApiTest.groovy
+++ b/client/src/test/groovy/jp/co/soramitsu/iroha/java/query/QueryApiTest.groovy
@@ -1,5 +1,6 @@
-package jp.co.soramitsu.iroha.java
+package jp.co.soramitsu.iroha.java.query
 
+import jp.co.soramitsu.iroha.java.*
 import jp.co.soramitsu.iroha.java.debug.Account
 import jp.co.soramitsu.iroha.testcontainers.IrohaContainer
 import jp.co.soramitsu.iroha.testcontainers.PeerConfig

--- a/testcontainers/src/main/java/jp/co/soramitsu/iroha/testcontainers/IrohaContainer.java
+++ b/testcontainers/src/main/java/jp/co/soramitsu/iroha/testcontainers/IrohaContainer.java
@@ -30,7 +30,9 @@ public class IrohaContainer extends FailureDetectingExternalResource implements 
   public static final String defaultPostgresAlias = "iroha.postgres";
   public static final String defaultIrohaAlias = "iroha";
   public static final String irohaWorkdir = "/opt/iroha_data";
-  public static final String defaultIrohaDockerImage = "warchantua/iroha:1.1.0";
+  // TODO (a.chernyshov) change tag to "hyperledger/iroha:1.2.0-rc.1" as soon as
+  // https://github.com/hyperledger/iroha/pull/606 with signature check fix is released
+  public static final String defaultIrohaDockerImage = "soramitsu/iroha:PR-606";
   public static final String defaultPostgresDockerImage = "postgres:11-alpine";
 
   // env vars

--- a/testcontainers/src/main/java/jp/co/soramitsu/iroha/testcontainers/IrohaContainer.java
+++ b/testcontainers/src/main/java/jp/co/soramitsu/iroha/testcontainers/IrohaContainer.java
@@ -32,7 +32,7 @@ public class IrohaContainer extends FailureDetectingExternalResource implements 
   public static final String irohaWorkdir = "/opt/iroha_data";
   // TODO (a.chernyshov) change tag to "hyperledger/iroha:1.2.0-rc.1" as soon as
   // https://github.com/hyperledger/iroha/pull/606 with signature check fix is released
-  public static final String defaultIrohaDockerImage = "soramitsu/iroha:PR-606";
+  public static final String defaultIrohaDockerImage = "soramitsu/iroha:support-1.2.x";
   public static final String defaultPostgresDockerImage = "postgres:11-alpine";
 
   // env vars

--- a/testcontainers/src/main/java/jp/co/soramitsu/iroha/testcontainers/IrohaContainer.java
+++ b/testcontainers/src/main/java/jp/co/soramitsu/iroha/testcontainers/IrohaContainer.java
@@ -30,7 +30,7 @@ public class IrohaContainer extends FailureDetectingExternalResource implements 
   public static final String defaultPostgresAlias = "iroha.postgres";
   public static final String defaultIrohaAlias = "iroha";
   public static final String irohaWorkdir = "/opt/iroha_data";
-  // TODO (a.chernyshov) change tag to "hyperledger/iroha:1.2.0-rc.1" as soon as
+  // TODO (a.chernyshov) change tag to "hyperledger/iroha:1.2.0-rc.?" as soon as
   // https://github.com/hyperledger/iroha/pull/606 with signature check fix is released
   public static final String defaultIrohaDockerImage = "soramitsu/iroha:support-1.2.x";
   public static final String defaultPostgresDockerImage = "postgres:11-alpine";

--- a/testcontainers/src/main/java/jp/co/soramitsu/iroha/testcontainers/detail/GenesisBlockBuilder.java
+++ b/testcontainers/src/main/java/jp/co/soramitsu/iroha/testcontainers/detail/GenesisBlockBuilder.java
@@ -19,8 +19,8 @@ import lombok.val;
 @NoArgsConstructor
 public class GenesisBlockBuilder {
 
-  /** Total permissions */
-  static final int TOTAL_PERMISSIONS_NUMBER = 46;
+  /** Max number of permissions = total permission - (undefined permission) - (0 index permission) */
+  static final int MAX_PERMISSION_NUMBER = RolePermission.values().length - 2;
 
   // this one must be equal to the name passed to iroha entrypoint.sh
   public static final String defaultGenesisBlockName = "genesis.block";
@@ -74,7 +74,7 @@ public class GenesisBlockBuilder {
         // give all permissions
         .createRole(
             defaultRoleName,
-            IntStream.range(0, TOTAL_PERMISSIONS_NUMBER + 1)
+            IntStream.range(0, MAX_PERMISSION_NUMBER)
                 .boxed()
                 .map(RolePermission::forNumber)
                 .collect(Collectors.toList())

--- a/testcontainers/src/main/java/jp/co/soramitsu/iroha/testcontainers/network/IrohaNetwork.java
+++ b/testcontainers/src/main/java/jp/co/soramitsu/iroha/testcontainers/network/IrohaNetwork.java
@@ -150,7 +150,7 @@ public class IrohaNetwork extends FailureDetectingExternalResource implements St
   public void start() {
     configure();
 
-    peers.parallelStream()
+    peers.stream()
         .map(pd -> pd.getContainer()
             .withNetwork(network)
             .withIrohaAlias(pd.getName())
@@ -162,7 +162,7 @@ public class IrohaNetwork extends FailureDetectingExternalResource implements St
    * Stop iroha network. Destroys all containers.
    */
   public void stop() {
-    peers.parallelStream()
+    peers.stream()
         .map(PeerDescriptor::getContainer)
         .forEach(IrohaContainer::stop);
   }


### PR DESCRIPTION
Update query and command protocols to Iroha 1.2.0.

 - Added `SetSettingValue` throwing "not allowed to use" exception.
 - Added `CallEngine` command.
 - Added GetEngineReceipts query.
 - All new permissions added.
 - Add Ordering for pagination
 - Add Ed25519/Sha2 support
 - Some minor fixes for readability.

What todo:
Todos with comments are left due to Iroha bugs to be fixed soon.
Public key in multihash format has not been implemented yet. 