### PR TITLE
Update io.grps and google protobuf libs version

### DIFF
--- a/client/proto.gradle
+++ b/client/proto.gradle
@@ -1,6 +1,6 @@
 ext {
-    grpcVersion = '1.12.0'
-    protobufVersion = '3.5.1'
+    grpcVersion = '1.29.0'
+    protobufVersion = '3.12.2'
 }
 
 repositories {
@@ -9,6 +9,7 @@ repositories {
 
 dependencies {
     compile "com.google.protobuf:protobuf-java:${protobufVersion}"
+    compile "com.google.protobuf:protobuf-java-util:${protobufVersion}"
     compile group: 'io.grpc', name: 'protoc-gen-grpc-java', version: grpcVersion, ext: 'pom'
     compile "io.grpc:grpc-stub:${grpcVersion}"
     compile "io.grpc:grpc-protobuf:${grpcVersion}"


### PR DESCRIPTION
For supporting fresh Spring Boot starters (2.2 and higher), JDK11, without downgrading for support versions of using libs