### PR TITLE
Added copying config and genesis files to Iroha container instead of mounting temporary folder

### DIFF
--- a/testcontainers/src/main/java/jp/co/soramitsu/iroha/testcontainers/IrohaContainer.java
+++ b/testcontainers/src/main/java/jp/co/soramitsu/iroha/testcontainers/IrohaContainer.java
@@ -1,7 +1,6 @@
 package jp.co.soramitsu.iroha.testcontainers;
 
 import static jp.co.soramitsu.iroha.java.Utils.nonNull;
-import static org.testcontainers.containers.BindMode.READ_ONLY;
 
 import java.io.Closeable;
 import java.io.File;
@@ -18,6 +17,7 @@ import org.testcontainers.containers.*;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.lifecycle.Startable;
+import org.testcontainers.utility.MountableFile;
 
 /**
  * If you get {@link com.github.dockerjava.api.exception.DockerException}: Mounts denied, please
@@ -94,7 +94,7 @@ public class IrohaContainer extends FailureDetectingExternalResource implements 
         .withEnv(VERBOSITY, verbosity)
         .withNetwork(network)
         .withExposedPorts(conf.getIrohaConfig().getTorii_port())
-        .withFileSystemBind(conf.getDir().getAbsolutePath(), irohaWorkdir, READ_ONLY)
+        .withCopyFileToContainer(MountableFile.forHostPath(conf.getDir().getAbsolutePath()), irohaWorkdir)
         .waitingFor(
             Wait.forLogMessage(".*iroha initialized.*\\s", 1)
                 .withStartupTimeout(Duration.ofSeconds(60))


### PR DESCRIPTION
**Motivation**
The library currently creates a temporary folder and writes the genesis file and configuration file there. Before the Iroha container starts, the temporary folder is mounted inside container and files become available to Iroha.

This approach works good if we run Iroha testcontainers on the host machine, but there is a drawback when we run the Iroha testcontainers as part of CI. Common approach to run tests in Docker containers. So, the build is executed  inside some docker container, and also Iroha testcontainers itself run Iroha container and it PostgreSQL container. Сontainers are run on the host machine near to build container. With this approach, need to mount same folder from host machine inside build container(there will be written config file and genesis file) and this folder also will be mount inside Iroha container. 
[See current flow schema](https://viewer.diagrams.net/?highlight=0000ff&edit=_blank&layers=1&nav=1#R3Zhbb5swFMc%2FTR4TBcz1sUl6kzppUqZue5occMArYGpMLv30M2ADDjRNlCbZlocWH9vH5uf%2F8TnJAEzjzT2FafiF%2BCga6GN%2FMwCzga5rmmPxf4VlW1lsy6gMAcW%2BGNQY5vgNCeNYWHPso0wZyAiJGE5Vo0eSBHlMsUFKyVodtiSRumoKA9QxzD0Yda3fsc%2FCyurodmN%2FQDgI5cqa5VY9MZSDxZtkIfTJumUCtwMwpYSw6ineTFFUwJNcqnl37%2FTWG6MoYYdMWLw9Py6%2BrfMw3jy7L8%2Fzh6XzOgSVlxWMcvHCDyRj5fa9ECdIbJ1tJY9sjeMI8g4w6W5A7GmFKEOblkls6B6RGDG65UNkr4Qj1KE5or1uWFumsIUtzoY0QnG%2BQe27QcAfBIUjiJgdItwNi9MOCUryxEeFqzGHsQ4xQ%2FMUekXvmscCt4Us5kvPtF5We4%2FjYIC6qQI0u%2Fxqxm1%2B1rnwycUUfjvkAo4uPZFIHfFwId2O95ICKqj6gmmRMp0eUnX8fj6qDqlJjvn1VL4agzz66HHht%2F9ADg%2FKjyXl9oDSzqYp%2B5ohqR%2BLD5gKPuvaEal1AxD5PMeJZkJKNanoCGUhCUgCoydCUgHsN2JsKzI0zBlRcXKKdPtDzC8bP4vGyJTN2abdOduK1pEyzkhOPfSxWBikAdrnUBOFScFi77FSFEGGV2o90HdKYupXghPWkoOxk%2BJ0U3VR7VTM2jnrehsnHH83xQ90K%2BJoJktSbrQRhvWaE9kxzMqTvuEDNCPdNJ38KSj%2BD4cx10zhQERjMfaOpNxyhykJ4S8fMijX4sZquWpyrySf4IJXj4qqYISDhD97XB38OgSTIg4xL89uREeMfT8qBYz4hkUyKHSVFkBLxOZkYM64JSrcc2n7iE5JRGi5MBiXn8OFqL13IRydkYbjkW7LQnKreDpRc5rb51TOJ8tlhs6jtW7x9Fgo4eopDdh%2FW06T14%2Ba1LrRc4EMV5%2Fav5vinA7MGfFeCrGNUbK6rOSuV1C6PZLaefOTEnuTy38qqbw%2FsXs5XZVKPf77z4dJ3jwwydsH5vjmRtYMW1cvT%2FdTrmSgaSMTOIalVX8NoKxiODuiqBB0qoLuVb%2FzBVC3dxy9U140ji6QFuTvApcpQcpvBhYsmpNkkaXVhP%2BrCpGh%2FhlFiKW71hmKkKHmjlxV5fbIBm7r45xemPBm8xNaNbz5IRLc%2FgE%3D)


With this fix, we don't need to mount folder from host machine inside build container. The library creates temporary folder inside build container and copy all files into Iroha container
[See fix schema](https://viewer.diagrams.net/?highlight=0000ff&edit=_blank&layers=1&nav=1&title=Untitled%20Diagram.drawio#R3ZdRb5swEMc%2FTaTtIZGNgcBjkzTrpFaaVGl7nBxwwC1wzJgm2aefARPi4lRru7bS8hI42%2Bfz7%2F5n7AlZ5vsvgpbpDcQsmzgo3k%2FIauI4GCNf%2FTWWQ2eZu05nSASPdafBcMt%2FM21E2lrzmFVGRwmQSV6axgiKgkXSsFEhYGd220JmzlrShI0MtxHNxtYfPJZpZw2c%2BWC%2FYjxJ%2B5mxH3YtOe0765VUKY1hd2IilxOyFACye8r3S5Y18Hou3bj1mdZjYIIV8m8G0PLaWV3VdfijuLxZb%2B%2FQ93I31V4eaFbrBV9BJdvwo5QXTIcuDz2PasfzjKoGstBDmZBsfzYmfFypkgiDnElxUF30gFCz0eJwPP2%2BG1D7gbalJ5hJb6Q6vcnR9UBAPWgIzwBCRkBGCBIBdXl28VqIdNN3R2Mo51NxlpRjkgotoIgF1HHcPwfljkAtaq6KqyUgqdKOeLV4zmfoLCeMZoFvoLJoCgfhDLtjWth%2FK1qeRVZrmZcjREpbRcwaV0hR2qVcstuSRk3rTu2wypbKXE29wq%2BC6D4JkQQzhOeOi8k8JBgRzwDqW4ASNCOuq7ZFL%2FAd5IfOGO6bsQ1GbL8KSOlHK9HFZsnadBgGMyd4Tx2GNh1CqXb8NW%2Bg%2FYyppB8lyuA%2FEmWf%2FBPSK4juGykiVjy8qyA%2F7iPhj9bJYnW80q8FtOs11QVCppBAQbNrgFJr6o5JedCHQ1pLsCmu8fw8XBjZeQmWUckfTG82NnroN%2BCFPCl8zyx87D7CK6lImNSjTk9sjxw1nynfOwre9U3JYxLOPNNzBbWI2Mhzm7vjAl%2Bezrll9%2FAzhXixhTbwIdH%2Brxr6hmnVZu5CdcBuuR8a1VOi%2F0%2B8dLYIyiYX%2BjPZDO76KMNpt95clbSwBrCh0X3SSmwaQQaii0Mkm0%2BOG7QTKBbIccPh2UOfbTFa9sljSN30ZkijSC2lcE036sJkqJlmPCnUc6TEq7YLsmh2Aq5uJBe6IedxnLWFwxRYfdBsSqds8t4qwVtMvJWyZI17VVIxE8tu8WpigtrfUzvNiw%2Bx%2FpNb%2BBTNnHl%2FdToYM76y5nBoc9qPh%2B22Ys%2BsCPU63M267sMNl1z%2BAQ%3D%3D)
