### PR TITLE
Removed PublicKeyWrapper due it shadowed default encoding

### DIFF
--- a/modules/client/src/main/kotlin/jp/co/soramitsu/iroha2/Extensions.kt
+++ b/modules/client/src/main/kotlin/jp/co/soramitsu/iroha2/Extensions.kt
@@ -44,7 +44,7 @@ fun ByteArray.hex(): String = Hex.toHexString(this)
 fun String.hex(): ByteArray = Hex.decode(this)
 
 fun PublicKey.toIrohaPublicKey(): jp.co.soramitsu.iroha2.generated.crypto.PublicKey {
-    return jp.co.soramitsu.iroha2.generated.crypto.PublicKey(DigestFunction.Ed25519.hashFunName, this.encoded)
+    return jp.co.soramitsu.iroha2.generated.crypto.PublicKey(DigestFunction.Ed25519.hashFunName, this.bytes())
 }
 
 /**

--- a/modules/client/src/test/kotlin/jp/co/soramitsu/iroha2/util/CryptoTest.kt
+++ b/modules/client/src/test/kotlin/jp/co/soramitsu/iroha2/util/CryptoTest.kt
@@ -1,5 +1,6 @@
 package jp.co.soramitsu.iroha2.util
 
+import jp.co.soramitsu.iroha2.bytes
 import jp.co.soramitsu.iroha2.generateKeyPair
 import jp.co.soramitsu.iroha2.hash
 import jp.co.soramitsu.iroha2.hex
@@ -37,7 +38,7 @@ class CryptoTest {
         runBlocking {
             assertEquals(
                 iterations,
-                futureResults.map { it.await().private.encoded }
+                futureResults.map { it.await().private.bytes() }
                     .map { ByteArrayWrapper(it) }
                     .toSet().size
             )
@@ -63,8 +64,8 @@ class CryptoTest {
     @Test
     fun `keypair serialized to hex and deserialized back`() {
         val keyPair = generateKeyPair()
-        val pubKey = keyPair.public.encoded.hex()
-        val privKey = keyPair.private.encoded.hex()
+        val pubKey = keyPair.public.bytes().hex()
+        val privKey = keyPair.private.bytes().hex()
 
         val message = "foo".toByteArray()
         val signature = keyPair.private.sign(message)


### PR DESCRIPTION
Currently we have wrappers for public and private keys what just override encoding format of the keys derived from third-party library. Library itself encodes them in X.509 format. We do not work with such format, but instead work with raw format. In this PR I made encoding explicit with introducing extension function. So encoding to X-509 is not shadowed buy our implementation