### PR TITLE
Fixed incorrect closing of websocket connection if peer responds with `Validating` event

### DIFF
--- a/modules/client/src/main/kotlin/jp/co/soramitsu/iroha2/Iroha2Client.kt
+++ b/modules/client/src/main/kotlin/jp/co/soramitsu/iroha2/Iroha2Client.kt
@@ -172,10 +172,10 @@ open class Iroha2Client(
                             )
                         )
                     }
-                    logger.debug("WebSocket is closing")
-                    this.close()
-                    logger.debug("WebSocket closed")
                 }
+                logger.debug("WebSocket is closing")
+                this.close()
+                logger.debug("WebSocket closed")
             }
         }
         return result


### PR DESCRIPTION
Peer can responds with 3 events signaling tx status: Committed, Rejected and Validating. Committed and Rejected are final statuses, so after receiving them client need to close socket connection, but after Validating status nothing need to do.

Signed-off-by: rkharisov <rinat@soramitsu.co.jp>