### PR TITLE
Iroha-206: metadata consistent ordering

### DIFF
--- a/modules/codegen/src/main/kotlin/jp/co/soramitsu/iroha2/codegen/generator/scale.kt
+++ b/modules/codegen/src/main/kotlin/jp/co/soramitsu/iroha2/codegen/generator/scale.kt
@@ -44,6 +44,7 @@ val COMPACT_BIG_INT_READER = CompactBigIntReader::class.asClassName()
 val SCALE_CODEC_EX_WRAPPER = MemberName("jp.co.soramitsu.iroha2", "wrapException")
 val TO_FIXED_POINT = MemberName("jp.co.soramitsu.iroha2", "toFixedPoint")
 val FROM_FIXED_POINT = MemberName("jp.co.soramitsu.iroha2", "fromFixedPoint")
+val IROHA_DATA_MODEL_NAME = "Name" // iroha_data_model::Name
 
 fun resolveScaleReadImpl(type: Type): CodeBlock {
     return when (type) {
@@ -135,13 +136,27 @@ fun resolveScaleWriteImpl(type: Type, propName: CodeBlock): CodeBlock {
             )
         }
         is MapType -> {
-            CodeBlock.of(
-                "writer.writeCompact(%1L.size)\n" +
-                    "%1L.forEach { (key, value) ->  \n\t%2L\n\t%3L\n}",
-                propName,
-                resolveScaleWriteImpl(type.key.requireValue(), CodeBlock.of("key")),
-                resolveScaleWriteImpl(type.value.requireValue(), CodeBlock.of("value"))
-            )
+            // Any Map<Name, T> will be sorted based on Name.string
+            // Initially required by Metadata ordering issue #206
+            val simpleName = (resolveKotlinType(type.key.requireValue()) as ClassName).simpleName
+            if (IROHA_DATA_MODEL_NAME.equals(simpleName)) {
+                CodeBlock.of(
+                    "writer.writeCompact(%1L.size)\n" +
+                        "%1L.toSortedMap(Comparator.comparing(%4T::string)).forEach { (key, value) ->  \n\t%2L\n\t%3L\n}",
+                    propName,
+                    resolveScaleWriteImpl(type.key.requireValue(), CodeBlock.of("key")),
+                    resolveScaleWriteImpl(type.value.requireValue(), CodeBlock.of("value")),
+                    withoutGenerics(resolveKotlinType(type.key.requireValue())),
+                )
+            } else {
+                CodeBlock.of(
+                    "writer.writeCompact(%1L.size)\n" +
+                        "%1L.forEach { (key, value) ->  \n\t%2L\n\t%3L\n}",
+                    propName,
+                    resolveScaleWriteImpl(type.key.requireValue(), CodeBlock.of("key")),
+                    resolveScaleWriteImpl(type.value.requireValue(), CodeBlock.of("value"))
+                )
+            }
         }
         is U8Type -> CodeBlock.of("writer.writeUByte(%L.toShort())", propName)
         is U16Type -> CodeBlock.of("writer.writeUint16(%L.toInt())", propName)

--- a/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/metadata/Metadata.kt
+++ b/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/metadata/Metadata.kt
@@ -31,7 +31,7 @@ public data class Metadata(
 
         public override fun write(writer: ScaleCodecWriter, instance: Metadata) = try {
             writer.writeCompact(instance.map.size)
-            instance.map.forEach { (key, value) ->  
+            instance.map.toSortedMap(Comparator.comparing(Name::string)).forEach { (key, value) ->
                 Name.write(writer, key)
                 Value.write(writer, value)
             }

--- a/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/permissions/PermissionToken.kt
+++ b/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/permissions/PermissionToken.kt
@@ -34,7 +34,7 @@ public data class PermissionToken(
         public override fun write(writer: ScaleCodecWriter, instance: PermissionToken) = try {
             Name.write(writer, instance.name)
             writer.writeCompact(instance.params.size)
-            instance.params.forEach { (key, value) ->  
+            instance.params.toSortedMap(Comparator.comparing(Name::string)).forEach { (key, value) ->  
                 Name.write(writer, key)
                 Value.write(writer, value)
             }

--- a/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/transaction/Payload.kt
+++ b/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/transaction/Payload.kt
@@ -49,7 +49,7 @@ public data class Payload(
             writer.writeUint64(instance.timeToLiveMs)
             writer.writeNullable(instance.nonce)
             writer.writeCompact(instance.metadata.size)
-            instance.metadata.forEach { (key, value) ->  
+            instance.metadata.toSortedMap(Comparator.comparing(Name::string)).forEach { (key, value) ->  
                 Name.write(writer, key)
                 Value.write(writer, value)
             }


### PR DESCRIPTION
Signed-off-by: Guskov Timur <guskov@soramitsu.co.jp>

According to issue #206 added metadata ordering.
Any Map<Name, ...> will first be sorted with natural ordering before encoding based on Name.string value.