### PR TITLE
Fix/iroha 213

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,14 @@ subprojects {
     apply plugin: 'maven-publish'
     apply plugin: 'org.jmailen.kotlinter'
 
+    publishing {
+        publications {
+            mavenJava(MavenPublication) {
+                from components.java
+            }
+        }
+    }
+
     group = 'jp.co.soramitsu.iroha-java'
     version = 'git rev-parse --short HEAD'.execute().text.trim()
 

--- a/modules/client/src/main/kotlin/jp/co/soramitsu/iroha2/transaction/Instructions.kt
+++ b/modules/client/src/main/kotlin/jp/co/soramitsu/iroha2/transaction/Instructions.kt
@@ -31,7 +31,6 @@ import jp.co.soramitsu.iroha2.generated.datamodel.asset.DefinitionId
 import jp.co.soramitsu.iroha2.generated.datamodel.domain.Domain
 import jp.co.soramitsu.iroha2.generated.datamodel.domain.IpfsPath
 import jp.co.soramitsu.iroha2.generated.datamodel.events.EventFilter
-import jp.co.soramitsu.iroha2.generated.datamodel.events.data.filters.FilterOptEntityFilter
 import jp.co.soramitsu.iroha2.generated.datamodel.events.time.ExecutionTime
 import jp.co.soramitsu.iroha2.generated.datamodel.events.time.Schedule
 import jp.co.soramitsu.iroha2.generated.datamodel.isi.BurnBox

--- a/modules/client/src/main/kotlin/jp/co/soramitsu/iroha2/transaction/Instructions.kt
+++ b/modules/client/src/main/kotlin/jp/co/soramitsu/iroha2/transaction/Instructions.kt
@@ -165,13 +165,13 @@ object Instructions {
     /**
      * Instruction for data trigger registration
      */
-    fun registerDataCreatedEventTrigger(
+    fun registerEventTrigger(
         triggerId: TriggerId,
         isi: List<Instruction>,
         repeats: Repeats,
         accountId: AccountId,
         metadata: Metadata,
-        filter: FilterOptEntityFilter
+        filter: EventFilter
     ): Instruction.Register {
         return registerSome {
             IdentifiableBox.Trigger(
@@ -181,9 +181,7 @@ object Instructions {
                         Executable.Instructions(isi),
                         repeats,
                         accountId,
-                        EventFilter.Data(
-                            filter
-                        )
+                        filter
                     ),
                     metadata
                 )

--- a/modules/client/src/main/kotlin/jp/co/soramitsu/iroha2/transaction/TransactionBuilder.kt
+++ b/modules/client/src/main/kotlin/jp/co/soramitsu/iroha2/transaction/TransactionBuilder.kt
@@ -13,7 +13,7 @@ import jp.co.soramitsu.iroha2.generated.datamodel.asset.AssetDefinitionEntry
 import jp.co.soramitsu.iroha2.generated.datamodel.asset.AssetValueType
 import jp.co.soramitsu.iroha2.generated.datamodel.asset.DefinitionId
 import jp.co.soramitsu.iroha2.generated.datamodel.domain.IpfsPath
-import jp.co.soramitsu.iroha2.generated.datamodel.events.data.filters.FilterOptEntityFilter
+import jp.co.soramitsu.iroha2.generated.datamodel.events.EventFilter
 import jp.co.soramitsu.iroha2.generated.datamodel.events.time.Schedule
 import jp.co.soramitsu.iroha2.generated.datamodel.isi.Instruction
 import jp.co.soramitsu.iroha2.generated.datamodel.metadata.Metadata
@@ -143,16 +143,16 @@ class TransactionBuilder(builder: TransactionBuilder.() -> Unit = {}) {
     }
 
     @JvmOverloads
-    fun registerDataCreatedEventTrigger(
+    fun registerEventTrigger(
         triggerId: TriggerId,
         isi: List<Instruction>,
         repeats: Repeats,
         accountId: AccountId,
         metadata: Metadata = Metadata(mapOf()),
-        filter: FilterOptEntityFilter
+        filter: EventFilter
     ) = this.apply {
         instructions.value.add(
-            Instructions.registerDataCreatedEventTrigger(
+            Instructions.registerEventTrigger(
                 triggerId,
                 isi,
                 repeats,

--- a/modules/client/src/test/kotlin/jp/co/soramitsu/iroha2/TriggersTest.kt
+++ b/modules/client/src/test/kotlin/jp/co/soramitsu/iroha2/TriggersTest.kt
@@ -76,18 +76,18 @@ class TriggersTest {
 
         // register trigger
         val filter = EventFilter.Data(
-                FilterOptEntityFilter.BySome(
-                        EntityFilter.ByAssetDefinition(
-                                FilterOptAssetDefinitionFilter.BySome(
-                                        AssetDefinitionFilter(
-                                                FilterOptIdFilterAssetDefinitionId.AcceptAll(),
-                                                FilterOptAssetDefinitionEventFilter.BySome(
-                                                        AssetDefinitionEventFilter.ByCreated()
-                                                )
-                                        )
-                                )
+            FilterOptEntityFilter.BySome(
+                EntityFilter.ByAssetDefinition(
+                    FilterOptAssetDefinitionFilter.BySome(
+                        AssetDefinitionFilter(
+                            FilterOptIdFilterAssetDefinitionId.AcceptAll(),
+                            FilterOptAssetDefinitionEventFilter.BySome(
+                                AssetDefinitionEventFilter.ByCreated()
+                            )
                         )
+                    )
                 )
+            )
         )
         client.sendTransaction {
             accountId = ALICE_ACCOUNT_ID

--- a/modules/client/src/test/kotlin/jp/co/soramitsu/iroha2/TriggersTest.kt
+++ b/modules/client/src/test/kotlin/jp/co/soramitsu/iroha2/TriggersTest.kt
@@ -14,6 +14,7 @@ import jp.co.soramitsu.iroha2.generated.datamodel.Name
 import jp.co.soramitsu.iroha2.generated.datamodel.asset.AssetValue
 import jp.co.soramitsu.iroha2.generated.datamodel.asset.AssetValueType
 import jp.co.soramitsu.iroha2.generated.datamodel.asset.DefinitionId
+import jp.co.soramitsu.iroha2.generated.datamodel.events.EventFilter
 import jp.co.soramitsu.iroha2.generated.datamodel.events.data.filters.EntityFilter
 import jp.co.soramitsu.iroha2.generated.datamodel.events.data.filters.FilterOptAssetDefinitionEventFilter
 import jp.co.soramitsu.iroha2.generated.datamodel.events.data.filters.FilterOptAssetDefinitionFilter
@@ -21,6 +22,7 @@ import jp.co.soramitsu.iroha2.generated.datamodel.events.data.filters.FilterOptE
 import jp.co.soramitsu.iroha2.generated.datamodel.events.data.filters.FilterOptIdFilterAssetDefinitionId
 import jp.co.soramitsu.iroha2.generated.datamodel.events.data.filters.asset.AssetDefinitionEventFilter
 import jp.co.soramitsu.iroha2.generated.datamodel.events.data.filters.asset.AssetDefinitionFilter
+import jp.co.soramitsu.iroha2.generated.datamodel.events.time.ExecutionTime
 import jp.co.soramitsu.iroha2.generated.datamodel.events.time.Schedule
 import jp.co.soramitsu.iroha2.generated.datamodel.isi.Instruction
 import jp.co.soramitsu.iroha2.generated.datamodel.metadata.Metadata
@@ -38,6 +40,7 @@ import org.junit.jupiter.api.parallel.ExecutionMode
 import java.math.BigInteger
 import java.security.KeyPair
 import java.time.Instant
+import java.util.Date
 import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -72,21 +75,23 @@ class TriggersTest {
         assertEquals(100L, prevQuantity)
 
         // register trigger
-        val filter = FilterOptEntityFilter.BySome(
-            EntityFilter.ByAssetDefinition(
-                FilterOptAssetDefinitionFilter.BySome(
-                    AssetDefinitionFilter(
-                        FilterOptIdFilterAssetDefinitionId.AcceptAll(),
-                        FilterOptAssetDefinitionEventFilter.BySome(
-                            AssetDefinitionEventFilter.ByCreated()
+        val filter = EventFilter.Data(
+                FilterOptEntityFilter.BySome(
+                        EntityFilter.ByAssetDefinition(
+                                FilterOptAssetDefinitionFilter.BySome(
+                                        AssetDefinitionFilter(
+                                                FilterOptIdFilterAssetDefinitionId.AcceptAll(),
+                                                FilterOptAssetDefinitionEventFilter.BySome(
+                                                        AssetDefinitionEventFilter.ByCreated()
+                                                )
+                                        )
+                                )
                         )
-                    )
                 )
-            )
         )
         client.sendTransaction {
             accountId = ALICE_ACCOUNT_ID
-            registerDataCreatedEventTrigger(
+            registerEventTrigger(
                 triggerId,
                 listOf(Instructions.mintAsset(DEFAULT_ASSET_ID, 1L)),
                 Repeats.Indefinitely(),

--- a/modules/client/src/test/kotlin/jp/co/soramitsu/iroha2/TriggersTest.kt
+++ b/modules/client/src/test/kotlin/jp/co/soramitsu/iroha2/TriggersTest.kt
@@ -24,7 +24,6 @@ import jp.co.soramitsu.iroha2.generated.datamodel.events.data.filters.FilterOptE
 import jp.co.soramitsu.iroha2.generated.datamodel.events.data.filters.FilterOptIdFilterAssetDefinitionId
 import jp.co.soramitsu.iroha2.generated.datamodel.events.data.filters.asset.AssetDefinitionEventFilter
 import jp.co.soramitsu.iroha2.generated.datamodel.events.data.filters.asset.AssetDefinitionFilter
-import jp.co.soramitsu.iroha2.generated.datamodel.events.time.ExecutionTime
 import jp.co.soramitsu.iroha2.generated.datamodel.events.time.Schedule
 import jp.co.soramitsu.iroha2.generated.datamodel.isi.Instruction
 import jp.co.soramitsu.iroha2.generated.datamodel.metadata.Metadata
@@ -42,8 +41,6 @@ import org.junit.jupiter.api.parallel.ExecutionMode
 import java.math.BigInteger
 import java.security.KeyPair
 import java.time.Instant
-import java.util.Date
-import java.util.concurrent.TimeUnit
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import jp.co.soramitsu.iroha2.generated.datamodel.account.Id as AccountId

--- a/modules/codegen/src/main/kotlin/jp/co/soramitsu/iroha2/EntryPoint.kt
+++ b/modules/codegen/src/main/kotlin/jp/co/soramitsu/iroha2/EntryPoint.kt
@@ -7,7 +7,6 @@ import com.fasterxml.jackson.databind.ObjectMapper
 import jp.co.soramitsu.iroha2.codegen.generator.GeneratorEntryPoint
 import jp.co.soramitsu.iroha2.parse.Schema
 import jp.co.soramitsu.iroha2.parse.SchemaParser
-import java.io.InputStreamReader
 import java.nio.file.Paths
 
 const val OUTPUT_PATH_ARG_NAME = "outputPath"
@@ -28,11 +27,11 @@ fun main(args: Array<String>) {
 
 fun getFilterEventName(name: String): String {
     if (name.contains("data::filters")) {
-        val res = name.substringBefore("<").substringAfterLast("::")
+        val newName = name.substringBefore("<").substringAfterLast("::")
         if (!name.contains("<")) {
-            return res.replace(">", "")
+            return newName.replace(">", "")
         } else {
-            return res + getFilterEventName(name.substringAfter("<"))
+            return newName + getFilterEventName(name.substringAfter("<"))
         }
     }
     val tokens = name.replace(">", "").split("::")
@@ -50,7 +49,7 @@ fun readSchema(fileName: String): Schema {
     return ObjectMapper().readValue(sb.toString(), object : TypeReference<Map<String, Any>>() {})
 }
 
-fun parseLine(line: String):String {
+fun parseLine(line: String): String {
     if (line.contains(schemaFilterPattern)) {
         var tmpLine = line.substringBeforeLast("\"").replace("\"", "").trim()
         if (tmpLine.startsWith(SCHEMA_FILTER_TY)) {

--- a/modules/codegen/src/main/kotlin/jp/co/soramitsu/iroha2/EntryPoint.kt
+++ b/modules/codegen/src/main/kotlin/jp/co/soramitsu/iroha2/EntryPoint.kt
@@ -12,6 +12,9 @@ import java.nio.file.Paths
 
 const val OUTPUT_PATH_ARG_NAME = "outputPath"
 const val SCHEMA_FILE_ARG_NAME = "schemaFileName"
+const val SCHEMA_FILTER_TY = "ty:"
+val schemaFilterPattern = "data::filters::(.+)<".toRegex()
+val schemaFilterRegex = "\"iroha_data_model::events::data::filters(.+)\"".toRegex()
 
 fun main(args: Array<String>) {
     val argsMap = parseArgs(args)
@@ -23,9 +26,45 @@ fun main(args: Array<String>) {
     GeneratorEntryPoint.generate(parseResult, outputPath)
 }
 
+fun getFilterEventName(name: String): String {
+    if (name.contains("data::filters")) {
+        val res = name.substringBefore("<").substringAfterLast("::")
+        if (!name.contains("<")) {
+            return res.replace(">", "")
+        } else {
+            return res + getFilterEventName(name.substringAfter("<"))
+        }
+    }
+    val tokens = name.replace(">", "").split("::")
+    val sb = StringBuilder()
+    for (i in 1 until tokens.size) {
+        sb.append(tokens[i].replaceFirstChar { tokens[i].first().uppercaseChar() })
+    }
+    return sb.toString()
+}
+
 fun readSchema(fileName: String): Schema {
     val resource = Thread.currentThread().contextClassLoader.getResourceAsStream(fileName)!!
-    return ObjectMapper().readValue(InputStreamReader(resource), object : TypeReference<Map<String, Any>>() {})
+    val sb = StringBuilder()
+    resource.bufferedReader().forEachLine { line -> sb.appendLine(parseLine(line)) }
+    return ObjectMapper().readValue(sb.toString(), object : TypeReference<Map<String, Any>>() {})
+}
+
+fun parseLine(line: String):String {
+    if (line.contains(schemaFilterPattern)) {
+        var tmpLine = line.substringBeforeLast("\"").replace("\"", "").trim()
+        if (tmpLine.startsWith(SCHEMA_FILTER_TY)) {
+            tmpLine = tmpLine.substring(SCHEMA_FILTER_TY.length + 1)
+        }
+        val newFilterName = getFilterEventName(tmpLine)
+        val newLine = "\"" + tmpLine.substringBefore(getDelimiter(line)) + newFilterName + "\""
+        return line.replace(schemaFilterRegex, newLine)
+    }
+    return line
+}
+
+fun getDelimiter(name: String): String {
+    return name.substringBefore("<").substringAfterLast("::")
 }
 
 fun parseArgs(args: Array<String>): Map<String, String> {

--- a/modules/codegen/src/main/resources/schema.json
+++ b/modules/codegen/src/main/resources/schema.json
@@ -1205,7 +1205,7 @@
         {
           "name": "Data",
           "discriminant": 1,
-          "ty": "iroha_data_model::events::data::filters::FilterOptEntityFilter"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::EntityFilter>"
         },
         {
           "name": "Time",
@@ -1528,42 +1528,42 @@
         {
           "name": "ByDomain",
           "discriminant": 0,
-          "ty": "iroha_data_model::events::data::filters::FilterOptDomainFilter"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::domain::DomainFilter>"
         },
         {
           "name": "ByPeer",
           "discriminant": 1,
-          "ty": "iroha_data_model::events::data::filters::FilterOptPeerFilter"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::peer::PeerFilter>"
         },
         {
           "name": "ByRole",
           "discriminant": 2,
-          "ty": "iroha_data_model::events::data::filters::FilterOptRoleFilter"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::role::RoleFilter>"
         },
         {
           "name": "ByAccount",
           "discriminant": 3,
-          "ty": "iroha_data_model::events::data::filters::FilterOptAccountFilter"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::account::AccountFilter>"
         },
         {
           "name": "ByAssetDefinition",
           "discriminant": 4,
-          "ty": "iroha_data_model::events::data::filters::FilterOptAssetDefinitionFilter"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::asset::AssetDefinitionFilter>"
         },
         {
           "name": "ByAsset",
           "discriminant": 5,
-          "ty": "iroha_data_model::events::data::filters::FilterOptAssetFilter"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::asset::AssetFilter>"
         },
         {
           "name": "ByTrigger",
           "discriminant": 6,
-          "ty": "iroha_data_model::events::data::filters::FilterOptTriggerFilter"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::trigger::TriggerFilter>"
         }
       ]
     }
   },
-  "iroha_data_model::events::data::filters::FilterOptEntityFilter": {
+  "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::EntityFilter>": {
     "Enum": {
       "variants": [
         {
@@ -1579,7 +1579,7 @@
       ]
     }
   },
-  "iroha_data_model::events::data::filters::FilterOptIdFilterAccountId": {
+  "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::IdFilter<iroha_data_model::account::Id>>": {
     "Enum": {
       "variants": [
         {
@@ -1590,12 +1590,12 @@
         {
           "name": "BySome",
           "discriminant": 1,
-          "ty": "iroha_data_model::events::data::filters::IdFilterAccountId"
+          "ty": "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::account::Id>"
         }
       ]
     }
   },
-  "iroha_data_model::events::data::filters::FilterOptIdFilterAssetDefinitionId": {
+  "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::IdFilter<iroha_data_model::asset::DefinitionId>>": {
     "Enum": {
       "variants": [
         {
@@ -1606,12 +1606,12 @@
         {
           "name": "BySome",
           "discriminant": 1,
-          "ty": "iroha_data_model::events::data::filters::IdFilterAssetDefinitionId"
+          "ty": "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::asset::DefinitionId>"
         }
       ]
     }
   },
-  "iroha_data_model::events::data::filters::FilterOptIdFilterAssetId": {
+  "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::IdFilter<iroha_data_model::asset::Id>>": {
     "Enum": {
       "variants": [
         {
@@ -1622,12 +1622,12 @@
         {
           "name": "BySome",
           "discriminant": 1,
-          "ty": "iroha_data_model::events::data::filters::IdFilterAssetId"
+          "ty": "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::asset::Id>"
         }
       ]
     }
   },
-  "iroha_data_model::events::data::filters::FilterOptIdFilterDomainId": {
+  "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::IdFilter<iroha_data_model::domain::Id>>": {
     "Enum": {
       "variants": [
         {
@@ -1638,12 +1638,12 @@
         {
           "name": "BySome",
           "discriminant": 1,
-          "ty": "iroha_data_model::events::data::filters::IdFilterDomainId"
+          "ty": "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::domain::Id>"
         }
       ]
     }
   },
-  "iroha_data_model::events::data::filters::FilterOptIdFilterPeerId": {
+  "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::IdFilter<iroha_data_model::peer::Id>>": {
     "Enum": {
       "variants": [
         {
@@ -1654,12 +1654,12 @@
         {
           "name": "BySome",
           "discriminant": 1,
-          "ty": "iroha_data_model::events::data::filters::IdFilterPeerId"
+          "ty": "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::peer::Id>"
         }
       ]
     }
   },
-  "iroha_data_model::events::data::filters::FilterOptIdFilterRoleId": {
+  "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::IdFilter<iroha_data_model::role::Id>>": {
     "Enum": {
       "variants": [
         {
@@ -1670,12 +1670,12 @@
         {
           "name": "BySome",
           "discriminant": 1,
-          "ty": "iroha_data_model::events::data::filters::IdFilterRoleId"
+          "ty": "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::role::Id>"
         }
       ]
     }
   },
-  "iroha_data_model::events::data::filters::FilterOptIdFilterTriggerId": {
+  "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::IdFilter<iroha_data_model::trigger::Id>>": {
     "Enum": {
       "variants": [
         {
@@ -1686,12 +1686,12 @@
         {
           "name": "BySome",
           "discriminant": 1,
-          "ty": "iroha_data_model::events::data::filters::IdFilterTriggerId"
+          "ty": "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::trigger::Id>"
         }
       ]
     }
   },
-  "iroha_data_model::events::data::filters::FilterOptAccountEventFilter": {
+  "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::account::AccountEventFilter>": {
     "Enum": {
       "variants": [
         {
@@ -1707,7 +1707,7 @@
       ]
     }
   },
-  "iroha_data_model::events::data::filters::FilterOptAccountFilter": {
+  "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::account::AccountFilter>": {
     "Enum": {
       "variants": [
         {
@@ -1723,7 +1723,7 @@
       ]
     }
   },
-  "iroha_data_model::events::data::filters::FilterOptAssetDefinitionEventFilter": {
+  "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::asset::AssetDefinitionEventFilter>": {
     "Enum": {
       "variants": [
         {
@@ -1739,7 +1739,7 @@
       ]
     }
   },
-  "iroha_data_model::events::data::filters::FilterOptAssetDefinitionFilter": {
+  "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::asset::AssetDefinitionFilter>": {
     "Enum": {
       "variants": [
         {
@@ -1755,7 +1755,7 @@
       ]
     }
   },
-  "iroha_data_model::events::data::filters::FilterOptAssetEventFilter": {
+  "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::asset::AssetEventFilter>": {
     "Enum": {
       "variants": [
         {
@@ -1771,7 +1771,7 @@
       ]
     }
   },
-  "iroha_data_model::events::data::filters::FilterOptAssetFilter": {
+  "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::asset::AssetFilter>": {
     "Enum": {
       "variants": [
         {
@@ -1787,7 +1787,7 @@
       ]
     }
   },
-  "iroha_data_model::events::data::filters::FilterOptDomainEventFilter": {
+  "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::domain::DomainEventFilter>": {
     "Enum": {
       "variants": [
         {
@@ -1803,7 +1803,7 @@
       ]
     }
   },
-  "iroha_data_model::events::data::filters::FilterOptDomainFilter": {
+  "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::domain::DomainFilter>": {
     "Enum": {
       "variants": [
         {
@@ -1819,7 +1819,7 @@
       ]
     }
   },
-  "iroha_data_model::events::data::filters::FilterOptPeerEventFilter": {
+  "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::peer::PeerEventFilter>": {
     "Enum": {
       "variants": [
         {
@@ -1835,7 +1835,7 @@
       ]
     }
   },
-  "iroha_data_model::events::data::filters::FilterOptPeerFilter": {
+  "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::peer::PeerFilter>": {
     "Enum": {
       "variants": [
         {
@@ -1851,7 +1851,7 @@
       ]
     }
   },
-  "iroha_data_model::events::data::filters::FilterOptRoleEventFilter": {
+  "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::role::RoleEventFilter>": {
     "Enum": {
       "variants": [
         {
@@ -1867,7 +1867,7 @@
       ]
     }
   },
-  "iroha_data_model::events::data::filters::FilterOptRoleFilter": {
+  "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::role::RoleFilter>": {
     "Enum": {
       "variants": [
         {
@@ -1883,7 +1883,7 @@
       ]
     }
   },
-  "iroha_data_model::events::data::filters::FilterOptTriggerEventFilter": {
+  "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::trigger::TriggerEventFilter>": {
     "Enum": {
       "variants": [
         {
@@ -1899,7 +1899,7 @@
       ]
     }
   },
-  "iroha_data_model::events::data::filters::FilterOptTriggerFilter": {
+  "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::trigger::TriggerFilter>": {
     "Enum": {
       "variants": [
         {
@@ -1915,49 +1915,49 @@
       ]
     }
   },
-  "iroha_data_model::events::data::filters::IdFilterAccountId": {
+  "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::account::Id>": {
     "TupleStruct": {
       "types": [
         "iroha_data_model::account::Id"
       ]
     }
   },
-  "iroha_data_model::events::data::filters::IdFilterAssetDefinitionId": {
+  "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::asset::DefinitionId>": {
     "TupleStruct": {
       "types": [
         "iroha_data_model::asset::DefinitionId"
       ]
     }
   },
-  "iroha_data_model::events::data::filters::IdFilterAssetId": {
+  "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::asset::Id>": {
     "TupleStruct": {
       "types": [
         "iroha_data_model::asset::Id"
       ]
     }
   },
-  "iroha_data_model::events::data::filters::IdFilterDomainId": {
+  "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::domain::Id>": {
     "TupleStruct": {
       "types": [
         "iroha_data_model::domain::Id"
       ]
     }
   },
-  "iroha_data_model::events::data::filters::IdFilterPeerId": {
+  "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::peer::Id>": {
     "TupleStruct": {
       "types": [
         "iroha_data_model::peer::Id"
       ]
     }
   },
-  "iroha_data_model::events::data::filters::IdFilterRoleId": {
+  "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::role::Id>": {
     "TupleStruct": {
       "types": [
         "iroha_data_model::role::Id"
       ]
     }
   },
-  "iroha_data_model::events::data::filters::IdFilterTriggerId": {
+  "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::trigger::Id>": {
     "TupleStruct": {
       "types": [
         "iroha_data_model::trigger::Id"
@@ -1970,7 +1970,7 @@
         {
           "name": "ByAsset",
           "discriminant": 0,
-          "ty": "iroha_data_model::events::data::filters::FilterOptAssetFilter"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::asset::AssetFilter>"
         },
         {
           "name": "ByCreated",
@@ -2020,11 +2020,11 @@
       "declarations": [
         {
           "name": "id_filter",
-          "ty": "iroha_data_model::events::data::filters::FilterOptIdFilterAccountId"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::IdFilter<iroha_data_model::account::Id>>"
         },
         {
           "name": "event_filter",
-          "ty": "iroha_data_model::events::data::filters::FilterOptAccountEventFilter"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::account::AccountEventFilter>"
         }
       ]
     }
@@ -2060,11 +2060,11 @@
       "declarations": [
         {
           "name": "id_filter",
-          "ty": "iroha_data_model::events::data::filters::FilterOptIdFilterAssetDefinitionId"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::IdFilter<iroha_data_model::asset::DefinitionId>>"
         },
         {
           "name": "event_filter",
-          "ty": "iroha_data_model::events::data::filters::FilterOptAssetDefinitionEventFilter"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::asset::AssetDefinitionEventFilter>"
         }
       ]
     }
@@ -2110,11 +2110,11 @@
       "declarations": [
         {
           "name": "id_filter",
-          "ty": "iroha_data_model::events::data::filters::FilterOptIdFilterAssetId"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::IdFilter<iroha_data_model::asset::Id>>"
         },
         {
           "name": "event_filter",
-          "ty": "iroha_data_model::events::data::filters::FilterOptAssetEventFilter"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::asset::AssetEventFilter>"
         }
       ]
     }
@@ -2125,12 +2125,12 @@
         {
           "name": "ByAccount",
           "discriminant": 0,
-          "ty": "iroha_data_model::events::data::filters::FilterOptAccountFilter"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::account::AccountFilter>"
         },
         {
           "name": "ByAssetDefinition",
           "discriminant": 1,
-          "ty": "iroha_data_model::events::data::filters::FilterOptAssetDefinitionFilter"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::asset::AssetDefinitionFilter>"
         },
         {
           "name": "ByCreated",
@@ -2160,11 +2160,11 @@
       "declarations": [
         {
           "name": "id_filter",
-          "ty": "iroha_data_model::events::data::filters::FilterOptIdFilterDomainId"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::IdFilter<iroha_data_model::domain::Id>>"
         },
         {
           "name": "event_filter",
-          "ty": "iroha_data_model::events::data::filters::FilterOptDomainEventFilter"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::domain::DomainEventFilter>"
         }
       ]
     }
@@ -2190,11 +2190,11 @@
       "declarations": [
         {
           "name": "id_filter",
-          "ty": "iroha_data_model::events::data::filters::FilterOptIdFilterPeerId"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::IdFilter<iroha_data_model::peer::Id>>"
         },
         {
           "name": "event_filter",
-          "ty": "iroha_data_model::events::data::filters::FilterOptPeerEventFilter"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::peer::PeerEventFilter>"
         }
       ]
     }
@@ -2220,11 +2220,11 @@
       "declarations": [
         {
           "name": "id_filter",
-          "ty": "iroha_data_model::events::data::filters::FilterOptIdFilterRoleId"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::IdFilter<iroha_data_model::role::Id>>"
         },
         {
           "name": "event_filter",
-          "ty": "iroha_data_model::events::data::filters::FilterOptRoleEventFilter"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::role::RoleEventFilter>"
         }
       ]
     }
@@ -2260,11 +2260,11 @@
       "declarations": [
         {
           "name": "id_filter",
-          "ty": "iroha_data_model::events::data::filters::FilterOptIdFilterTriggerId"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::IdFilter<iroha_data_model::trigger::Id>>"
         },
         {
           "name": "event_filter",
-          "ty": "iroha_data_model::events::data::filters::FilterOptTriggerEventFilter"
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::trigger::TriggerEventFilter>"
         }
       ]
     }

--- a/modules/codegen/src/main/resources/schema.json
+++ b/modules/codegen/src/main/resources/schema.json
@@ -1,63 +1,14 @@
 {
-  "BTreeMap<String, iroha_data_model::expression::EvaluatesTo<iroha_data_model::Value>>": {
-    "Map": {
-      "key": "String",
-      "value": "iroha_data_model::expression::EvaluatesTo<iroha_data_model::Value>"
+  "Compact<u128>": {
+    "Int": "Compact"
+  },
+  "Duration": {
+    "Tuple": {
+      "types": [
+        "u64",
+        "u32"
+      ]
     }
-  },
-  "BTreeMap<iroha_crypto::PublicKey, iroha_crypto::signature::SignatureOf<iroha_core::block::CommittedBlock>>": {
-    "Map": {
-      "key": "iroha_crypto::PublicKey",
-      "value": "iroha_crypto::signature::SignatureOf<iroha_core::block::CommittedBlock>"
-    }
-  },
-  "BTreeMap<iroha_crypto::PublicKey, iroha_crypto::signature::SignatureOf<iroha_core::sumeragi::view_change::Proof>>": {
-    "Map": {
-      "key": "iroha_crypto::PublicKey",
-      "value": "iroha_crypto::signature::SignatureOf<iroha_core::sumeragi::view_change::Proof>"
-    }
-  },
-  "BTreeMap<iroha_crypto::PublicKey, iroha_crypto::signature::SignatureOf<iroha_data_model::transaction::Payload>>": {
-    "Map": {
-      "key": "iroha_crypto::PublicKey",
-      "value": "iroha_crypto::signature::SignatureOf<iroha_data_model::transaction::Payload>"
-    }
-  },
-  "BTreeMap<iroha_data_model::Name, iroha_data_model::Value>": {
-    "Map": {
-      "key": "iroha_data_model::Name",
-      "value": "iroha_data_model::Value"
-    }
-  },
-  "BTreeMap<iroha_data_model::account::Id, iroha_data_model::account::Account>": {
-    "Map": {
-      "key": "iroha_data_model::account::Id",
-      "value": "iroha_data_model::account::Account"
-    }
-  },
-  "BTreeMap<iroha_data_model::asset::DefinitionId, iroha_data_model::asset::AssetDefinitionEntry>": {
-    "Map": {
-      "key": "iroha_data_model::asset::DefinitionId",
-      "value": "iroha_data_model::asset::AssetDefinitionEntry"
-    }
-  },
-  "BTreeMap<iroha_data_model::asset::Id, iroha_data_model::asset::Asset>": {
-    "Map": {
-      "key": "iroha_data_model::asset::Id",
-      "value": "iroha_data_model::asset::Asset"
-    }
-  },
-  "BTreeSet<iroha_crypto::signature::SignatureOf<iroha_core::block::ValidBlock>>": {
-    "Vec": "iroha_crypto::signature::SignatureOf<iroha_core::block::ValidBlock>"
-  },
-  "BTreeSet<iroha_crypto::signature::SignatureOf<iroha_data_model::transaction::Payload>>": {
-    "Vec": "iroha_crypto::signature::SignatureOf<iroha_data_model::transaction::Payload>"
-  },
-  "BTreeSet<iroha_data_model::permissions::PermissionToken>": {
-    "Vec": "iroha_data_model::permissions::PermissionToken"
-  },
-  "BTreeSet<iroha_data_model::role::Id>": {
-    "Vec": "iroha_data_model::role::Id"
   },
   "FixedPoint<i64>": {
     "FixedPoint": {
@@ -65,8 +16,64 @@
       "decimal_places": 9
     }
   },
-  "Option<core::time::Duration>": {
-    "Option": "core::time::Duration"
+  "Map<String, iroha_data_model::expression::EvaluatesTo<iroha_data_model::Value>>": {
+    "Map": {
+      "key": "String",
+      "value": "iroha_data_model::expression::EvaluatesTo<iroha_data_model::Value>",
+      "sorted_by_key": true
+    }
+  },
+  "Map<iroha_crypto::PublicKey, iroha_crypto::signature::SignatureOf<iroha_core::block::CommittedBlock>>": {
+    "Map": {
+      "key": "iroha_crypto::PublicKey",
+      "value": "iroha_crypto::signature::SignatureOf<iroha_core::block::CommittedBlock>",
+      "sorted_by_key": true
+    }
+  },
+  "Map<iroha_crypto::PublicKey, iroha_crypto::signature::SignatureOf<iroha_core::sumeragi::view_change::Proof>>": {
+    "Map": {
+      "key": "iroha_crypto::PublicKey",
+      "value": "iroha_crypto::signature::SignatureOf<iroha_core::sumeragi::view_change::Proof>",
+      "sorted_by_key": true
+    }
+  },
+  "Map<iroha_crypto::PublicKey, iroha_crypto::signature::SignatureOf<iroha_data_model::transaction::Payload>>": {
+    "Map": {
+      "key": "iroha_crypto::PublicKey",
+      "value": "iroha_crypto::signature::SignatureOf<iroha_data_model::transaction::Payload>",
+      "sorted_by_key": true
+    }
+  },
+  "Map<iroha_data_model::Name, iroha_data_model::Value>": {
+    "Map": {
+      "key": "iroha_data_model::Name",
+      "value": "iroha_data_model::Value",
+      "sorted_by_key": true
+    }
+  },
+  "Map<iroha_data_model::account::Id, iroha_data_model::account::Account>": {
+    "Map": {
+      "key": "iroha_data_model::account::Id",
+      "value": "iroha_data_model::account::Account",
+      "sorted_by_key": true
+    }
+  },
+  "Map<iroha_data_model::asset::DefinitionId, iroha_data_model::asset::AssetDefinitionEntry>": {
+    "Map": {
+      "key": "iroha_data_model::asset::DefinitionId",
+      "value": "iroha_data_model::asset::AssetDefinitionEntry",
+      "sorted_by_key": true
+    }
+  },
+  "Map<iroha_data_model::asset::Id, iroha_data_model::asset::Asset>": {
+    "Map": {
+      "key": "iroha_data_model::asset::Id",
+      "value": "iroha_data_model::asset::Asset",
+      "sorted_by_key": true
+    }
+  },
+  "Option<Duration>": {
+    "Option": "Duration"
   },
   "Option<iroha_core::sumeragi::network_topology::Topology>": {
     "Option": "iroha_core::sumeragi::network_topology::Topology"
@@ -77,8 +84,11 @@
   "Option<iroha_data_model::domain::IpfsPath>": {
     "Option": "iroha_data_model::domain::IpfsPath"
   },
-  "Option<iroha_data_model::events::pipeline::EntityType>": {
-    "Option": "iroha_data_model::events::pipeline::EntityType"
+  "Option<iroha_data_model::events::pipeline::EntityKind>": {
+    "Option": "iroha_data_model::events::pipeline::EntityKind"
+  },
+  "Option<iroha_data_model::events::pipeline::StatusKind>": {
+    "Option": "iroha_data_model::events::pipeline::StatusKind"
   },
   "Option<iroha_data_model::events::time::Interval>": {
     "Option": "iroha_data_model::events::time::Interval"
@@ -91,62 +101,103 @@
   },
   "String": "String",
   "Vec<iroha_core::genesis::GenesisTransaction>": {
-    "Vec": "iroha_core::genesis::GenesisTransaction"
+    "Vec": {
+      "ty": "iroha_core::genesis::GenesisTransaction",
+      "sorted": false
+    }
   },
   "Vec<iroha_core::sumeragi::view_change::Proof>": {
-    "Vec": "iroha_core::sumeragi::view_change::Proof"
+    "Vec": {
+      "ty": "iroha_core::sumeragi::view_change::Proof",
+      "sorted": false
+    }
   },
   "Vec<iroha_crypto::PublicKey>": {
-    "Vec": "iroha_crypto::PublicKey"
+    "Vec": {
+      "ty": "iroha_crypto::PublicKey",
+      "sorted": true
+    }
   },
   "Vec<iroha_crypto::hash::HashOf<iroha_core::block::VersionedValidBlock>>": {
-    "Vec": "iroha_crypto::hash::HashOf<iroha_core::block::VersionedValidBlock>"
+    "Vec": {
+      "ty": "iroha_crypto::hash::HashOf<iroha_core::block::VersionedValidBlock>",
+      "sorted": false
+    }
   },
   "Vec<iroha_crypto::signature::SignatureOf<iroha_core::block::ValidBlock>>": {
-    "Vec": "iroha_crypto::signature::SignatureOf<iroha_core::block::ValidBlock>"
+    "Vec": {
+      "ty": "iroha_crypto::signature::SignatureOf<iroha_core::block::ValidBlock>",
+      "sorted": true
+    }
   },
   "Vec<iroha_crypto::signature::SignatureOf<iroha_data_model::transaction::Payload>>": {
-    "Vec": "iroha_crypto::signature::SignatureOf<iroha_data_model::transaction::Payload>"
+    "Vec": {
+      "ty": "iroha_crypto::signature::SignatureOf<iroha_data_model::transaction::Payload>",
+      "sorted": true
+    }
   },
   "Vec<iroha_data_model::Value>": {
-    "Vec": "iroha_data_model::Value"
+    "Vec": {
+      "ty": "iroha_data_model::Value",
+      "sorted": false
+    }
   },
   "Vec<iroha_data_model::events::Event>": {
-    "Vec": "iroha_data_model::events::Event"
+    "Vec": {
+      "ty": "iroha_data_model::events::Event",
+      "sorted": false
+    }
   },
   "Vec<iroha_data_model::isi::Instruction>": {
-    "Vec": "iroha_data_model::isi::Instruction"
+    "Vec": {
+      "ty": "iroha_data_model::isi::Instruction",
+      "sorted": false
+    }
   },
   "Vec<iroha_data_model::peer::Id>": {
-    "Vec": "iroha_data_model::peer::Id"
+    "Vec": {
+      "ty": "iroha_data_model::peer::Id",
+      "sorted": false
+    }
   },
   "Vec<iroha_data_model::permissions::PermissionToken>": {
-    "Vec": "iroha_data_model::permissions::PermissionToken"
+    "Vec": {
+      "ty": "iroha_data_model::permissions::PermissionToken",
+      "sorted": true
+    }
+  },
+  "Vec<iroha_data_model::role::Id>": {
+    "Vec": {
+      "ty": "iroha_data_model::role::Id",
+      "sorted": true
+    }
   },
   "Vec<iroha_data_model::transaction::VersionedRejectedTransaction>": {
-    "Vec": "iroha_data_model::transaction::VersionedRejectedTransaction"
+    "Vec": {
+      "ty": "iroha_data_model::transaction::VersionedRejectedTransaction",
+      "sorted": false
+    }
   },
   "Vec<iroha_data_model::transaction::VersionedValidTransaction>": {
-    "Vec": "iroha_data_model::transaction::VersionedValidTransaction"
+    "Vec": {
+      "ty": "iroha_data_model::transaction::VersionedValidTransaction",
+      "sorted": false
+    }
   },
   "Vec<u8>": {
-    "Vec": "u8"
+    "Vec": {
+      "ty": "u8",
+      "sorted": false
+    }
   },
   "[u8; 32]": {
     "Array": {
       "ty": "u8",
-      "len": 32
+      "len": 32,
+      "sorted": false
     }
   },
   "bool": "Bool",
-  "core::time::Duration": {
-    "TupleStruct": {
-      "types": [
-        "u64",
-        "u32"
-      ]
-    }
-  },
   "i64": {
     "Int": "FixedWidth"
   },
@@ -171,11 +222,11 @@
         },
         {
           "name": "transactions_hash",
-          "ty": "iroha_crypto::hash::HashOf<iroha_data_model::merkle::MerkleTree<iroha_data_model::transaction::VersionedTransaction>>"
+          "ty": "iroha_crypto::hash::HashOf<iroha_crypto::merkle::MerkleTree<iroha_data_model::transaction::VersionedTransaction>>"
         },
         {
           "name": "rejected_transactions_hash",
-          "ty": "iroha_crypto::hash::HashOf<iroha_data_model::merkle::MerkleTree<iroha_data_model::transaction::VersionedTransaction>>"
+          "ty": "iroha_crypto::hash::HashOf<iroha_crypto::merkle::MerkleTree<iroha_data_model::transaction::VersionedTransaction>>"
         },
         {
           "name": "view_change_proofs",
@@ -235,7 +286,7 @@
         },
         {
           "name": "signatures",
-          "ty": "BTreeSet<iroha_crypto::signature::SignatureOf<iroha_core::block::ValidBlock>>"
+          "ty": "Vec<iroha_crypto::signature::SignatureOf<iroha_core::block::ValidBlock>>"
         },
         {
           "name": "event_recommendations",
@@ -369,40 +420,40 @@
           "ty": "iroha_data_model::Name"
         },
         {
-          "name": "Role",
-          "discriminant": 5,
-          "ty": "iroha_data_model::role::Id"
-        },
-        {
           "name": "Block",
-          "discriminant": 6,
+          "discriminant": 5,
           "ty": "iroha_core::smartcontracts::isi::error::ParentHashNotFound"
         },
         {
           "name": "Transaction",
-          "discriminant": 7,
+          "discriminant": 6,
           "ty": "iroha_crypto::hash::HashOf<iroha_data_model::transaction::VersionedTransaction>"
         },
         {
           "name": "Context",
-          "discriminant": 8,
+          "discriminant": 7,
           "ty": "String"
         },
         {
           "name": "Peer",
-          "discriminant": 9,
+          "discriminant": 8,
           "ty": "iroha_data_model::peer::Id"
         },
         {
           "name": "Trigger",
-          "discriminant": 10,
+          "discriminant": 9,
           "ty": "iroha_data_model::trigger::Id"
+        },
+        {
+          "name": "Role",
+          "discriminant": 10,
+          "ty": "iroha_data_model::role::Id"
         }
       ]
     }
   },
   "iroha_core::smartcontracts::isi::error::ParentHashNotFound": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "iroha_crypto::hash::HashOf<iroha_core::block::VersionedCommittedBlock>"
       ]
@@ -467,10 +518,6 @@
           "ty": "Vec<iroha_data_model::peer::Id>"
         },
         {
-          "name": "reshuffle_after_n_view_changes",
-          "ty": "u64"
-        },
-        {
           "name": "at_block",
           "ty": "iroha_crypto::hash::HashOf<iroha_core::block::VersionedCommittedBlock>"
         },
@@ -482,7 +529,7 @@
     }
   },
   "iroha_core::sumeragi::view_change::BlockCreationTimeout": {
-    "TupleStruct": {
+    "Tuple": {
       "types": []
     }
   },
@@ -497,7 +544,7 @@
     }
   },
   "iroha_core::sumeragi::view_change::NoTransactionReceiptReceived": {
-    "TupleStruct": {
+    "Tuple": {
       "types": []
     }
   },
@@ -579,52 +626,51 @@
     }
   },
   "iroha_crypto::hash::Hash": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "[u8; 32]"
       ]
     }
   },
   "iroha_crypto::hash::HashOf<iroha_core::block::VersionedCommittedBlock>": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "iroha_crypto::hash::Hash"
       ]
     }
   },
   "iroha_crypto::hash::HashOf<iroha_core::block::VersionedValidBlock>": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "iroha_crypto::hash::Hash"
       ]
     }
   },
   "iroha_crypto::hash::HashOf<iroha_core::sumeragi::view_change::Proof>": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "iroha_crypto::hash::Hash"
       ]
     }
   },
-  "iroha_crypto::hash::HashOf<iroha_data_model::merkle::MerkleTree<iroha_data_model::transaction::VersionedTransaction>>": {
-    "TupleStruct": {
-      "types": [
-        "iroha_crypto::hash::Hash"
-      ]
-    }
-  },
-  "iroha_crypto::hash::HashOf<iroha_data_model::merkle::Node<iroha_data_model::transaction::VersionedTransaction>>": {
-    "TupleStruct": {
+  "iroha_crypto::hash::HashOf<iroha_crypto::merkle::MerkleTree<iroha_data_model::transaction::VersionedTransaction>>": {
+    "Tuple": {
       "types": [
         "iroha_crypto::hash::Hash"
       ]
     }
   },
   "iroha_crypto::hash::HashOf<iroha_data_model::transaction::VersionedTransaction>": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "iroha_crypto::hash::Hash"
       ]
+    }
+  },
+  "iroha_crypto::merkle::MerkleTree<iroha_data_model::transaction::VersionedTransaction>": {
+    "Vec": {
+      "ty": "iroha_crypto::hash::HashOf<iroha_data_model::transaction::VersionedTransaction>",
+      "sorted": true
     }
   },
   "iroha_crypto::signature::Signature": {
@@ -635,42 +681,42 @@
           "ty": "iroha_crypto::PublicKey"
         },
         {
-          "name": "signature",
+          "name": "payload",
           "ty": "Vec<u8>"
         }
       ]
     }
   },
   "iroha_crypto::signature::SignatureOf<iroha_core::block::CommittedBlock>": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "iroha_crypto::signature::Signature"
       ]
     }
   },
   "iroha_crypto::signature::SignatureOf<iroha_core::block::ValidBlock>": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "iroha_crypto::signature::Signature"
       ]
     }
   },
   "iroha_crypto::signature::SignatureOf<iroha_core::sumeragi::view_change::Proof>": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "iroha_crypto::signature::Signature"
       ]
     }
   },
   "iroha_crypto::signature::SignatureOf<iroha_data_model::query::Payload>": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "iroha_crypto::signature::Signature"
       ]
     }
   },
   "iroha_crypto::signature::SignatureOf<iroha_data_model::transaction::Payload>": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "iroha_crypto::signature::Signature"
       ]
@@ -681,7 +727,7 @@
       "declarations": [
         {
           "name": "signatures",
-          "ty": "BTreeMap<iroha_crypto::PublicKey, iroha_crypto::signature::SignatureOf<iroha_core::block::CommittedBlock>>"
+          "ty": "Map<iroha_crypto::PublicKey, iroha_crypto::signature::SignatureOf<iroha_core::block::CommittedBlock>>"
         }
       ]
     }
@@ -691,7 +737,7 @@
       "declarations": [
         {
           "name": "signatures",
-          "ty": "BTreeMap<iroha_crypto::PublicKey, iroha_crypto::signature::SignatureOf<iroha_core::sumeragi::view_change::Proof>>"
+          "ty": "Map<iroha_crypto::PublicKey, iroha_crypto::signature::SignatureOf<iroha_core::sumeragi::view_change::Proof>>"
         }
       ]
     }
@@ -701,7 +747,7 @@
       "declarations": [
         {
           "name": "signatures",
-          "ty": "BTreeMap<iroha_crypto::PublicKey, iroha_crypto::signature::SignatureOf<iroha_data_model::transaction::Payload>>"
+          "ty": "Map<iroha_crypto::PublicKey, iroha_crypto::signature::SignatureOf<iroha_data_model::transaction::Payload>>"
         }
       ]
     }
@@ -710,14 +756,14 @@
     "Enum": {
       "variants": [
         {
-          "name": "AccountId",
+          "name": "DomainId",
           "discriminant": 0,
-          "ty": "iroha_data_model::account::Id"
+          "ty": "iroha_data_model::domain::Id"
         },
         {
-          "name": "AssetId",
+          "name": "AccountId",
           "discriminant": 1,
-          "ty": "iroha_data_model::asset::Id"
+          "ty": "iroha_data_model::account::Id"
         },
         {
           "name": "AssetDefinitionId",
@@ -725,9 +771,9 @@
           "ty": "iroha_data_model::asset::DefinitionId"
         },
         {
-          "name": "DomainId",
+          "name": "AssetId",
           "discriminant": 3,
-          "ty": "iroha_data_model::domain::Id"
+          "ty": "iroha_data_model::asset::Id"
         },
         {
           "name": "PeerId",
@@ -735,19 +781,14 @@
           "ty": "iroha_data_model::peer::Id"
         },
         {
-          "name": "RoleId",
-          "discriminant": 5,
-          "ty": "iroha_data_model::role::Id"
-        },
-        {
           "name": "TriggerId",
-          "discriminant": 6,
+          "discriminant": 5,
           "ty": "iroha_data_model::trigger::Id"
         },
         {
-          "name": "WorldId",
-          "discriminant": 7,
-          "ty": null
+          "name": "RoleId",
+          "discriminant": 6,
+          "ty": "iroha_data_model::role::Id"
         }
       ]
     }
@@ -756,39 +797,39 @@
     "Enum": {
       "variants": [
         {
-          "name": "Account",
-          "discriminant": 0,
-          "ty": "iroha_data_model::account::Account"
-        },
-        {
-          "name": "NewAccount",
-          "discriminant": 1,
-          "ty": "iroha_data_model::account::NewAccount"
-        },
-        {
-          "name": "Asset",
-          "discriminant": 2,
-          "ty": "iroha_data_model::asset::Asset"
-        },
-        {
-          "name": "AssetDefinition",
-          "discriminant": 3,
-          "ty": "iroha_data_model::asset::AssetDefinition"
-        },
-        {
-          "name": "Domain",
-          "discriminant": 4,
-          "ty": "iroha_data_model::domain::Domain"
-        },
-        {
           "name": "Peer",
-          "discriminant": 5,
+          "discriminant": 0,
           "ty": "iroha_data_model::peer::Peer"
         },
         {
-          "name": "Role",
+          "name": "NewDomain",
+          "discriminant": 1,
+          "ty": "iroha_data_model::domain::NewDomain"
+        },
+        {
+          "name": "NewAccount",
+          "discriminant": 2,
+          "ty": "iroha_data_model::account::NewAccount"
+        },
+        {
+          "name": "Domain",
+          "discriminant": 3,
+          "ty": "iroha_data_model::domain::Domain"
+        },
+        {
+          "name": "Account",
+          "discriminant": 4,
+          "ty": "iroha_data_model::account::Account"
+        },
+        {
+          "name": "AssetDefinition",
+          "discriminant": 5,
+          "ty": "iroha_data_model::asset::AssetDefinition"
+        },
+        {
+          "name": "Asset",
           "discriminant": 6,
-          "ty": "iroha_data_model::role::Role"
+          "ty": "iroha_data_model::asset::Asset"
         },
         {
           "name": "Trigger",
@@ -796,15 +837,15 @@
           "ty": "iroha_data_model::trigger::Trigger"
         },
         {
-          "name": "World",
+          "name": "Role",
           "discriminant": 8,
-          "ty": null
+          "ty": "iroha_data_model::role::Role"
         }
       ]
     }
   },
   "iroha_data_model::Name": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "String"
       ]
@@ -832,6 +873,47 @@
           "name": "TransactionReceiptTime",
           "discriminant": 3,
           "ty": "u128"
+        }
+      ]
+    }
+  },
+  "iroha_data_model::RegistrableBox": {
+    "Enum": {
+      "variants": [
+        {
+          "name": "Peer",
+          "discriminant": 0,
+          "ty": "iroha_data_model::peer::Peer"
+        },
+        {
+          "name": "Domain",
+          "discriminant": 1,
+          "ty": "iroha_data_model::domain::NewDomain"
+        },
+        {
+          "name": "Account",
+          "discriminant": 2,
+          "ty": "iroha_data_model::account::NewAccount"
+        },
+        {
+          "name": "AssetDefinition",
+          "discriminant": 3,
+          "ty": "iroha_data_model::asset::AssetDefinition"
+        },
+        {
+          "name": "Asset",
+          "discriminant": 4,
+          "ty": "iroha_data_model::asset::Asset"
+        },
+        {
+          "name": "Trigger",
+          "discriminant": 5,
+          "ty": "iroha_data_model::trigger::Trigger"
+        },
+        {
+          "name": "Role",
+          "discriminant": 6,
+          "ty": "iroha_data_model::role::Role"
         }
       ]
     }
@@ -931,7 +1013,7 @@
         },
         {
           "name": "assets",
-          "ty": "BTreeMap<iroha_data_model::asset::Id, iroha_data_model::asset::Asset>"
+          "ty": "Map<iroha_data_model::asset::Id, iroha_data_model::asset::Asset>"
         },
         {
           "name": "signatories",
@@ -939,7 +1021,7 @@
         },
         {
           "name": "permission_tokens",
-          "ty": "BTreeSet<iroha_data_model::permissions::PermissionToken>"
+          "ty": "Vec<iroha_data_model::permissions::PermissionToken>"
         },
         {
           "name": "signature_check_condition",
@@ -951,7 +1033,7 @@
         },
         {
           "name": "roles",
-          "ty": "BTreeSet<iroha_data_model::role::Id>"
+          "ty": "Vec<iroha_data_model::role::Id>"
         }
       ]
     }
@@ -989,7 +1071,7 @@
     }
   },
   "iroha_data_model::account::SignatureCheckCondition": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "iroha_data_model::expression::EvaluatesTo<bool>"
       ]
@@ -1013,20 +1095,20 @@
     "Struct": {
       "declarations": [
         {
-          "name": "value_type",
-          "ty": "iroha_data_model::asset::AssetValueType"
-        },
-        {
           "name": "id",
           "ty": "iroha_data_model::asset::DefinitionId"
         },
         {
-          "name": "metadata",
-          "ty": "iroha_data_model::metadata::Metadata"
+          "name": "value_type",
+          "ty": "iroha_data_model::asset::AssetValueType"
         },
         {
           "name": "mintable",
-          "ty": "bool"
+          "ty": "iroha_data_model::asset::Mintable"
+        },
+        {
+          "name": "metadata",
+          "ty": "iroha_data_model::metadata::Metadata"
         }
       ]
     }
@@ -1125,6 +1207,27 @@
       ]
     }
   },
+  "iroha_data_model::asset::Mintable": {
+    "Enum": {
+      "variants": [
+        {
+          "name": "Infinitely",
+          "discriminant": 0,
+          "ty": null
+        },
+        {
+          "name": "Once",
+          "discriminant": 1,
+          "ty": null
+        },
+        {
+          "name": "Not",
+          "discriminant": 2,
+          "ty": null
+        }
+      ]
+    }
+  },
   "iroha_data_model::domain::Domain": {
     "Struct": {
       "declarations": [
@@ -1134,19 +1237,19 @@
         },
         {
           "name": "accounts",
-          "ty": "BTreeMap<iroha_data_model::account::Id, iroha_data_model::account::Account>"
+          "ty": "Map<iroha_data_model::account::Id, iroha_data_model::account::Account>"
         },
         {
           "name": "asset_definitions",
-          "ty": "BTreeMap<iroha_data_model::asset::DefinitionId, iroha_data_model::asset::AssetDefinitionEntry>"
-        },
-        {
-          "name": "metadata",
-          "ty": "iroha_data_model::metadata::Metadata"
+          "ty": "Map<iroha_data_model::asset::DefinitionId, iroha_data_model::asset::AssetDefinitionEntry>"
         },
         {
           "name": "logo",
           "ty": "Option<iroha_data_model::domain::IpfsPath>"
+        },
+        {
+          "name": "metadata",
+          "ty": "iroha_data_model::metadata::Metadata"
         }
       ]
     }
@@ -1162,9 +1265,27 @@
     }
   },
   "iroha_data_model::domain::IpfsPath": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "String"
+      ]
+    }
+  },
+  "iroha_data_model::domain::NewDomain": {
+    "Struct": {
+      "declarations": [
+        {
+          "name": "id",
+          "ty": "iroha_data_model::domain::Id"
+        },
+        {
+          "name": "logo",
+          "ty": "Option<iroha_data_model::domain::IpfsPath>"
+        },
+        {
+          "name": "metadata",
+          "ty": "iroha_data_model::metadata::Metadata"
+        }
       ]
     }
   },
@@ -1278,39 +1399,39 @@
     "Enum": {
       "variants": [
         {
-          "name": "Domain",
-          "discriminant": 0,
-          "ty": "iroha_data_model::events::data::events::domain::DomainEvent"
-        },
-        {
           "name": "Peer",
-          "discriminant": 1,
+          "discriminant": 0,
           "ty": "iroha_data_model::events::data::events::peer::PeerEvent"
         },
         {
-          "name": "Role",
-          "discriminant": 2,
-          "ty": "iroha_data_model::events::data::events::role::RoleEvent"
+          "name": "Domain",
+          "discriminant": 1,
+          "ty": "iroha_data_model::events::data::events::domain::DomainEvent"
         },
         {
           "name": "Account",
-          "discriminant": 3,
+          "discriminant": 2,
           "ty": "iroha_data_model::events::data::events::account::AccountEvent"
         },
         {
           "name": "AssetDefinition",
-          "discriminant": 4,
+          "discriminant": 3,
           "ty": "iroha_data_model::events::data::events::asset::AssetDefinitionEvent"
         },
         {
           "name": "Asset",
-          "discriminant": 5,
+          "discriminant": 4,
           "ty": "iroha_data_model::events::data::events::asset::AssetEvent"
         },
         {
           "name": "Trigger",
-          "discriminant": 6,
+          "discriminant": 5,
           "ty": "iroha_data_model::events::data::events::trigger::TriggerEvent"
+        },
+        {
+          "name": "Role",
+          "discriminant": 6,
+          "ty": "iroha_data_model::events::data::events::role::RoleEvent"
         }
       ]
     }
@@ -1375,18 +1496,23 @@
           "ty": "iroha_data_model::asset::DefinitionId"
         },
         {
-          "name": "Deleted",
+          "name": "MintabilityChanged",
           "discriminant": 1,
           "ty": "iroha_data_model::asset::DefinitionId"
         },
         {
-          "name": "MetadataInserted",
+          "name": "Deleted",
           "discriminant": 2,
           "ty": "iroha_data_model::asset::DefinitionId"
         },
         {
-          "name": "MetadataRemoved",
+          "name": "MetadataInserted",
           "discriminant": 3,
+          "ty": "iroha_data_model::asset::DefinitionId"
+        },
+        {
+          "name": "MetadataRemoved",
+          "discriminant": 4,
           "ty": "iroha_data_model::asset::DefinitionId"
         }
       ]
@@ -1526,39 +1652,39 @@
     "Enum": {
       "variants": [
         {
-          "name": "ByDomain",
-          "discriminant": 0,
-          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::domain::DomainFilter>"
-        },
-        {
           "name": "ByPeer",
-          "discriminant": 1,
+          "discriminant": 0,
           "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::peer::PeerFilter>"
         },
         {
-          "name": "ByRole",
-          "discriminant": 2,
-          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::role::RoleFilter>"
+          "name": "ByDomain",
+          "discriminant": 1,
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::domain::DomainFilter>"
         },
         {
           "name": "ByAccount",
-          "discriminant": 3,
+          "discriminant": 2,
           "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::account::AccountFilter>"
         },
         {
           "name": "ByAssetDefinition",
-          "discriminant": 4,
+          "discriminant": 3,
           "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::asset::AssetDefinitionFilter>"
         },
         {
           "name": "ByAsset",
-          "discriminant": 5,
+          "discriminant": 4,
           "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::asset::AssetFilter>"
         },
         {
           "name": "ByTrigger",
-          "discriminant": 6,
+          "discriminant": 5,
           "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::trigger::TriggerFilter>"
+        },
+        {
+          "name": "ByRole",
+          "discriminant": 6,
+          "ty": "iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::role::RoleFilter>"
         }
       ]
     }
@@ -1916,49 +2042,49 @@
     }
   },
   "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::account::Id>": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "iroha_data_model::account::Id"
       ]
     }
   },
   "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::asset::DefinitionId>": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "iroha_data_model::asset::DefinitionId"
       ]
     }
   },
   "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::asset::Id>": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "iroha_data_model::asset::Id"
       ]
     }
   },
   "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::domain::Id>": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "iroha_data_model::domain::Id"
       ]
     }
   },
   "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::peer::Id>": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "iroha_data_model::peer::Id"
       ]
     }
   },
   "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::role::Id>": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "iroha_data_model::role::Id"
       ]
     }
   },
   "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::trigger::Id>": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "iroha_data_model::trigger::Id"
       ]
@@ -2043,13 +2169,18 @@
           "ty": null
         },
         {
-          "name": "ByMetadataInserted",
+          "name": "ByMintabilityChanged",
           "discriminant": 2,
           "ty": null
         },
         {
-          "name": "ByMetadataRemoved",
+          "name": "ByMetadataInserted",
           "discriminant": 3,
+          "ty": null
+        },
+        {
+          "name": "ByMetadataRemoved",
+          "discriminant": 4,
           "ty": null
         }
       ]
@@ -2297,7 +2428,7 @@
       ]
     }
   },
-  "iroha_data_model::events::pipeline::EntityType": {
+  "iroha_data_model::events::pipeline::EntityKind": {
     "Enum": {
       "variants": [
         {
@@ -2317,8 +2448,8 @@
     "Struct": {
       "declarations": [
         {
-          "name": "entity_type",
-          "ty": "iroha_data_model::events::pipeline::EntityType"
+          "name": "entity_kind",
+          "ty": "iroha_data_model::events::pipeline::EntityKind"
         },
         {
           "name": "status",
@@ -2335,8 +2466,12 @@
     "Struct": {
       "declarations": [
         {
-          "name": "entity",
-          "ty": "Option<iroha_data_model::events::pipeline::EntityType>"
+          "name": "entity_kind",
+          "ty": "Option<iroha_data_model::events::pipeline::EntityKind>"
+        },
+        {
+          "name": "status_kind",
+          "ty": "Option<iroha_data_model::events::pipeline::StatusKind>"
         },
         {
           "name": "hash",
@@ -2366,6 +2501,27 @@
       ]
     }
   },
+  "iroha_data_model::events::pipeline::StatusKind": {
+    "Enum": {
+      "variants": [
+        {
+          "name": "Validating",
+          "discriminant": 0,
+          "ty": null
+        },
+        {
+          "name": "Rejected",
+          "discriminant": 1,
+          "ty": null
+        },
+        {
+          "name": "Committed",
+          "discriminant": 2,
+          "ty": null
+        }
+      ]
+    }
+  },
   "iroha_data_model::events::time::Event": {
     "Struct": {
       "declarations": [
@@ -2381,7 +2537,7 @@
     }
   },
   "iroha_data_model::events::time::EventFilter": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "iroha_data_model::events::time::ExecutionTime"
       ]
@@ -2408,11 +2564,11 @@
       "declarations": [
         {
           "name": "since",
-          "ty": "core::time::Duration"
+          "ty": "Duration"
         },
         {
           "name": "length",
-          "ty": "core::time::Duration"
+          "ty": "Duration"
         }
       ]
     }
@@ -2422,11 +2578,11 @@
       "declarations": [
         {
           "name": "start",
-          "ty": "core::time::Duration"
+          "ty": "Duration"
         },
         {
           "name": "period",
-          "ty": "Option<core::time::Duration>"
+          "ty": "Option<Duration>"
         }
       ]
     }
@@ -2579,7 +2735,7 @@
       ]
     }
   },
-  "iroha_data_model::expression::EvaluatesTo<iroha_data_model::IdentifiableBox>": {
+  "iroha_data_model::expression::EvaluatesTo<iroha_data_model::Name>": {
     "Struct": {
       "declarations": [
         {
@@ -2589,7 +2745,7 @@
       ]
     }
   },
-  "iroha_data_model::expression::EvaluatesTo<iroha_data_model::Name>": {
+  "iroha_data_model::expression::EvaluatesTo<iroha_data_model::RegistrableBox>": {
     "Struct": {
       "declarations": [
         {
@@ -2640,6 +2796,26 @@
     }
   },
   "iroha_data_model::expression::EvaluatesTo<iroha_data_model::domain::Id>": {
+    "Struct": {
+      "declarations": [
+        {
+          "name": "expression",
+          "ty": "iroha_data_model::expression::Expression"
+        }
+      ]
+    }
+  },
+  "iroha_data_model::expression::EvaluatesTo<iroha_data_model::role::Id>": {
+    "Struct": {
+      "declarations": [
+        {
+          "name": "expression",
+          "ty": "iroha_data_model::expression::Expression"
+        }
+      ]
+    }
+  },
+  "iroha_data_model::expression::EvaluatesTo<iroha_data_model::trigger::Id>": {
     "Struct": {
       "declarations": [
         {
@@ -2900,7 +3076,7 @@
         },
         {
           "name": "values",
-          "ty": "BTreeMap<String, iroha_data_model::expression::EvaluatesTo<iroha_data_model::Value>>"
+          "ty": "Map<String, iroha_data_model::expression::EvaluatesTo<iroha_data_model::Value>>"
         }
       ]
     }
@@ -3080,7 +3256,7 @@
       "declarations": [
         {
           "name": "object",
-          "ty": "iroha_data_model::expression::EvaluatesTo<iroha_data_model::IdentifiableBox>"
+          "ty": "iroha_data_model::expression::EvaluatesTo<iroha_data_model::RegistrableBox>"
         }
       ]
     }
@@ -3169,71 +3345,26 @@
       ]
     }
   },
-  "iroha_data_model::merkle::Leaf<iroha_data_model::transaction::VersionedTransaction>": {
-    "Struct": {
-      "declarations": [
-        {
-          "name": "hash",
-          "ty": "iroha_crypto::hash::HashOf<iroha_data_model::transaction::VersionedTransaction>"
-        }
-      ]
-    }
-  },
-  "iroha_data_model::merkle::MerkleTree<iroha_data_model::transaction::VersionedTransaction>": {
-    "Struct": {
-      "declarations": [
-        {
-          "name": "root_node",
-          "ty": "iroha_data_model::merkle::Node<iroha_data_model::transaction::VersionedTransaction>"
-        }
-      ]
-    }
-  },
-  "iroha_data_model::merkle::Node<iroha_data_model::transaction::VersionedTransaction>": {
-    "Enum": {
-      "variants": [
-        {
-          "name": "Subtree",
-          "discriminant": 0,
-          "ty": "iroha_data_model::merkle::Subtree<iroha_data_model::transaction::VersionedTransaction>"
-        },
-        {
-          "name": "Leaf",
-          "discriminant": 1,
-          "ty": "iroha_data_model::merkle::Leaf<iroha_data_model::transaction::VersionedTransaction>"
-        },
-        {
-          "name": "Empty",
-          "discriminant": 2,
-          "ty": null
-        }
-      ]
-    }
-  },
-  "iroha_data_model::merkle::Subtree<iroha_data_model::transaction::VersionedTransaction>": {
-    "Struct": {
-      "declarations": [
-        {
-          "name": "left",
-          "ty": "iroha_data_model::merkle::Node<iroha_data_model::transaction::VersionedTransaction>"
-        },
-        {
-          "name": "right",
-          "ty": "iroha_data_model::merkle::Node<iroha_data_model::transaction::VersionedTransaction>"
-        },
-        {
-          "name": "hash",
-          "ty": "iroha_crypto::hash::HashOf<iroha_data_model::merkle::Node<iroha_data_model::transaction::VersionedTransaction>>"
-        }
-      ]
-    }
-  },
   "iroha_data_model::metadata::Metadata": {
     "Struct": {
       "declarations": [
         {
           "name": "map",
-          "ty": "BTreeMap<iroha_data_model::Name, iroha_data_model::Value>"
+          "ty": "Map<iroha_data_model::Name, iroha_data_model::Value>"
+        }
+      ]
+    }
+  },
+  "iroha_data_model::pagination::Pagination": {
+    "Struct": {
+      "declarations": [
+        {
+          "name": "start",
+          "ty": "Option<u32>"
+        },
+        {
+          "name": "limit",
+          "ty": "Option<u32>"
         }
       ]
     }
@@ -3271,7 +3402,25 @@
         },
         {
           "name": "params",
-          "ty": "BTreeMap<iroha_data_model::Name, iroha_data_model::Value>"
+          "ty": "Map<iroha_data_model::Name, iroha_data_model::Value>"
+        }
+      ]
+    }
+  },
+  "iroha_data_model::query::PaginatedQueryResult": {
+    "Struct": {
+      "declarations": [
+        {
+          "name": "result",
+          "ty": "iroha_data_model::query::QueryResult"
+        },
+        {
+          "name": "pagination",
+          "ty": "iroha_data_model::pagination::Pagination"
+        },
+        {
+          "name": "total",
+          "ty": "u64"
         }
       ]
     }
@@ -3281,7 +3430,7 @@
       "declarations": [
         {
           "name": "timestamp_ms",
-          "ty": "iroha_schema::Compact<u128>"
+          "ty": "Compact<u128>"
         },
         {
           "name": "query",
@@ -3408,25 +3557,50 @@
           "ty": "iroha_data_model::query::transaction::FindTransactionByHash"
         },
         {
-          "name": "FindAllRoles",
+          "name": "FindPermissionTokensByAccountId",
           "discriminant": 22,
+          "ty": "iroha_data_model::query::permissions::FindPermissionTokensByAccountId"
+        },
+        {
+          "name": "FindAllActiveTriggerIds",
+          "discriminant": 23,
+          "ty": "iroha_data_model::query::trigger::FindAllActiveTriggerIds"
+        },
+        {
+          "name": "FindTriggerById",
+          "discriminant": 24,
+          "ty": "iroha_data_model::query::trigger::FindTriggerById"
+        },
+        {
+          "name": "FindTriggerKeyValueByIdAndKey",
+          "discriminant": 25,
+          "ty": "iroha_data_model::query::trigger::FindTriggerKeyValueByIdAndKey"
+        },
+        {
+          "name": "FindAllRoles",
+          "discriminant": 26,
           "ty": "iroha_data_model::query::role::FindAllRoles"
         },
         {
-          "name": "FindRolesByAccountId",
-          "discriminant": 23,
-          "ty": "iroha_data_model::query::role::FindRolesByAccountId"
+          "name": "FindAllRoleIds",
+          "discriminant": 27,
+          "ty": "iroha_data_model::query::role::FindAllRoleIds"
         },
         {
-          "name": "FindPermissionTokensByAccountId",
-          "discriminant": 24,
-          "ty": "iroha_data_model::query::permissions::FindPermissionTokensByAccountId"
+          "name": "FindRoleByRoleId",
+          "discriminant": 28,
+          "ty": "iroha_data_model::query::role::FindRoleByRoleId"
+        },
+        {
+          "name": "FindRolesByAccountId",
+          "discriminant": 29,
+          "ty": "iroha_data_model::query::role::FindRolesByAccountId"
         }
       ]
     }
   },
   "iroha_data_model::query::QueryResult": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "iroha_data_model::Value"
       ]
@@ -3446,13 +3620,13 @@
       ]
     }
   },
-  "iroha_data_model::query::VersionedQueryResult": {
+  "iroha_data_model::query::VersionedPaginatedQueryResult": {
     "Enum": {
       "variants": [
         {
           "name": "V1",
           "discriminant": 1,
-          "ty": "iroha_data_model::query::QueryResult"
+          "ty": "iroha_data_model::query::PaginatedQueryResult"
         }
       ]
     }
@@ -3513,18 +3687,18 @@
     }
   },
   "iroha_data_model::query::account::FindAllAccounts": {
-    "Struct": {
-      "declarations": []
+    "Tuple": {
+      "types": []
     }
   },
   "iroha_data_model::query::asset::FindAllAssets": {
-    "Struct": {
-      "declarations": []
+    "Tuple": {
+      "types": []
     }
   },
   "iroha_data_model::query::asset::FindAllAssetsDefinitions": {
-    "Struct": {
-      "declarations": []
+    "Tuple": {
+      "types": []
     }
   },
   "iroha_data_model::query::asset::FindAssetById": {
@@ -3630,8 +3804,8 @@
     }
   },
   "iroha_data_model::query::domain::FindAllDomains": {
-    "Struct": {
-      "declarations": []
+    "Tuple": {
+      "types": []
     }
   },
   "iroha_data_model::query::domain::FindDomainById": {
@@ -3659,8 +3833,8 @@
     }
   },
   "iroha_data_model::query::peer::FindAllPeers": {
-    "Struct": {
-      "declarations": []
+    "Tuple": {
+      "types": []
     }
   },
   "iroha_data_model::query::permissions::FindPermissionTokensByAccountId": {
@@ -3673,9 +3847,24 @@
       ]
     }
   },
+  "iroha_data_model::query::role::FindAllRoleIds": {
+    "Tuple": {
+      "types": []
+    }
+  },
   "iroha_data_model::query::role::FindAllRoles": {
+    "Tuple": {
+      "types": []
+    }
+  },
+  "iroha_data_model::query::role::FindRoleByRoleId": {
     "Struct": {
-      "declarations": []
+      "declarations": [
+        {
+          "name": "id",
+          "ty": "iroha_data_model::expression::EvaluatesTo<iroha_data_model::role::Id>"
+        }
+      ]
     }
   },
   "iroha_data_model::query::role::FindRolesByAccountId": {
@@ -3708,6 +3897,35 @@
       ]
     }
   },
+  "iroha_data_model::query::trigger::FindAllActiveTriggerIds": {
+    "Tuple": {
+      "types": []
+    }
+  },
+  "iroha_data_model::query::trigger::FindTriggerById": {
+    "Struct": {
+      "declarations": [
+        {
+          "name": "id",
+          "ty": "iroha_data_model::expression::EvaluatesTo<iroha_data_model::trigger::Id>"
+        }
+      ]
+    }
+  },
+  "iroha_data_model::query::trigger::FindTriggerKeyValueByIdAndKey": {
+    "Struct": {
+      "declarations": [
+        {
+          "name": "id",
+          "ty": "iroha_data_model::expression::EvaluatesTo<iroha_data_model::trigger::Id>"
+        },
+        {
+          "name": "key",
+          "ty": "iroha_data_model::expression::EvaluatesTo<iroha_data_model::Name>"
+        }
+      ]
+    }
+  },
   "iroha_data_model::role::Id": {
     "Struct": {
       "declarations": [
@@ -3727,7 +3945,7 @@
         },
         {
           "name": "permissions",
-          "ty": "BTreeSet<iroha_data_model::permissions::PermissionToken>"
+          "ty": "Vec<iroha_data_model::permissions::PermissionToken>"
         }
       ]
     }
@@ -3808,7 +4026,7 @@
         },
         {
           "name": "metadata",
-          "ty": "BTreeMap<iroha_data_model::Name, iroha_data_model::Value>"
+          "ty": "Map<iroha_data_model::Name, iroha_data_model::Value>"
         }
       ]
     }
@@ -3856,13 +4074,13 @@
         },
         {
           "name": "signatures",
-          "ty": "BTreeSet<iroha_crypto::signature::SignatureOf<iroha_data_model::transaction::Payload>>"
+          "ty": "Vec<iroha_crypto::signature::SignatureOf<iroha_data_model::transaction::Payload>>"
         }
       ]
     }
   },
   "iroha_data_model::transaction::TransactionLimitError": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "String"
       ]
@@ -4015,6 +4233,10 @@
         {
           "name": "filter",
           "ty": "iroha_data_model::events::EventFilter"
+        },
+        {
+          "name": "metadata",
+          "ty": "iroha_data_model::metadata::Metadata"
         }
       ]
     }
@@ -4055,23 +4277,16 @@
         {
           "name": "action",
           "ty": "iroha_data_model::trigger::Action"
-        },
-        {
-          "name": "metadata",
-          "ty": "iroha_data_model::metadata::Metadata"
         }
       ]
     }
   },
   "iroha_data_primitives::fixed::Fixed": {
-    "TupleStruct": {
+    "Tuple": {
       "types": [
         "FixedPoint<i64>"
       ]
     }
-  },
-  "iroha_schema::Compact<u128>": {
-    "Int": "Compact"
   },
   "iroha_version::RawVersioned": {
     "Enum": {

--- a/modules/codegen/src/main/resources/schema.json
+++ b/modules/codegen/src/main/resources/schema.json
@@ -1590,7 +1590,7 @@
         {
           "name": "BySome",
           "discriminant": 1,
-          "ty": "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::account::Id>"
+          "ty": "iroha_data_model::events::data::filters::IdFilterAccountId"
         }
       ]
     }
@@ -1606,7 +1606,7 @@
         {
           "name": "BySome",
           "discriminant": 1,
-          "ty": "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::asset::DefinitionId>"
+          "ty": "iroha_data_model::events::data::filters::IdFilterAssetDefinitionId"
         }
       ]
     }
@@ -1622,7 +1622,7 @@
         {
           "name": "BySome",
           "discriminant": 1,
-          "ty": "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::asset::Id>"
+          "ty": "iroha_data_model::events::data::filters::IdFilterAssetId"
         }
       ]
     }
@@ -1638,7 +1638,7 @@
         {
           "name": "BySome",
           "discriminant": 1,
-          "ty": "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::domain::Id>"
+          "ty": "iroha_data_model::events::data::filters::IdFilterDomainId"
         }
       ]
     }
@@ -1654,7 +1654,7 @@
         {
           "name": "BySome",
           "discriminant": 1,
-          "ty": "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::peer::Id>"
+          "ty": "iroha_data_model::events::data::filters::IdFilterPeerId"
         }
       ]
     }
@@ -1670,7 +1670,7 @@
         {
           "name": "BySome",
           "discriminant": 1,
-          "ty": "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::role::Id>"
+          "ty": "iroha_data_model::events::data::filters::IdFilterRoleId"
         }
       ]
     }
@@ -1686,7 +1686,7 @@
         {
           "name": "BySome",
           "discriminant": 1,
-          "ty": "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::trigger::Id>"
+          "ty": "iroha_data_model::events::data::filters::IdFilterTriggerId"
         }
       ]
     }
@@ -1915,49 +1915,49 @@
       ]
     }
   },
-  "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::account::Id>": {
+  "iroha_data_model::events::data::filters::IdFilterAccountId": {
     "TupleStruct": {
       "types": [
         "iroha_data_model::account::Id"
       ]
     }
   },
-  "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::asset::DefinitionId>": {
+  "iroha_data_model::events::data::filters::IdFilterAssetDefinitionId": {
     "TupleStruct": {
       "types": [
         "iroha_data_model::asset::DefinitionId"
       ]
     }
   },
-  "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::asset::Id>": {
+  "iroha_data_model::events::data::filters::IdFilterAssetId": {
     "TupleStruct": {
       "types": [
         "iroha_data_model::asset::Id"
       ]
     }
   },
-  "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::domain::Id>": {
+  "iroha_data_model::events::data::filters::IdFilterDomainId": {
     "TupleStruct": {
       "types": [
         "iroha_data_model::domain::Id"
       ]
     }
   },
-  "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::peer::Id>": {
+  "iroha_data_model::events::data::filters::IdFilterPeerId": {
     "TupleStruct": {
       "types": [
         "iroha_data_model::peer::Id"
       ]
     }
   },
-  "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::role::Id>": {
+  "iroha_data_model::events::data::filters::IdFilterRoleId": {
     "TupleStruct": {
       "types": [
         "iroha_data_model::role::Id"
       ]
     }
   },
-  "iroha_data_model::events::data::filters::IdFilter<iroha_data_model::trigger::Id>": {
+  "iroha_data_model::events::data::filters::IdFilterTriggerId": {
     "TupleStruct": {
       "types": [
         "iroha_data_model::trigger::Id"

--- a/modules/codegen/src/test/kotlin/jp/co/soramitsu/iroha2/parse/SchemaParserTest.kt
+++ b/modules/codegen/src/test/kotlin/jp/co/soramitsu/iroha2/parse/SchemaParserTest.kt
@@ -148,22 +148,22 @@ class SchemaParserTest {
     fun `should parse compact numeric types`() {
         val schemaJson = """
         {
-          "iroha_schema::Compact<u8>": {
+          "Compact<u8>": {
             "Int": "Compact"
           },
-          "iroha_schema::Compact<u16>": {
+          "Compact<u16>": {
             "Int": "Compact"
           },
-          "iroha_schema::Compact<u32>": {
+          "Compact<u32>": {
             "Int": "Compact"
           },
-          "iroha_schema::Compact<u64>": {
+          "Compact<u64>": {
             "Int": "Compact"
           },
-          "iroha_schema::Compact<u128>": {
+          "Compact<u128>": {
             "Int": "Compact"
           },
-          "iroha_schema::Compact<u256>": {
+          "Compact<u256>": {
             "Int": "Compact"
           }
         }
@@ -180,12 +180,12 @@ class SchemaParserTest {
         }
 
         assertEquals(6, types.size)
-        assertAll(types["iroha_schema::Compact<u8>"], U8Type)
-        assertAll(types["iroha_schema::Compact<u16>"], U16Type)
-        assertAll(types["iroha_schema::Compact<u32>"], U32Type)
-        assertAll(types["iroha_schema::Compact<u64>"], U64Type)
-        assertAll(types["iroha_schema::Compact<u128>"], U128Type)
-        assertAll(types["iroha_schema::Compact<u256>"], U256Type)
+        assertAll(types["Compact<u8>"], U8Type)
+        assertAll(types["Compact<u16>"], U16Type)
+        assertAll(types["Compact<u32>"], U32Type)
+        assertAll(types["Compact<u64>"], U64Type)
+        assertAll(types["Compact<u128>"], U128Type)
+        assertAll(types["Compact<u256>"], U256Type)
     }
 
     @Test
@@ -193,7 +193,7 @@ class SchemaParserTest {
         val structName = "foo::bar::Zulu"
         val schemaJson = """
         {
-            "BTreeMap<String, $structName>": {
+            "Map<String, $structName>": {
                 "Map": {
                   "key": "String",
                   "value": "$structName"
@@ -216,11 +216,11 @@ class SchemaParserTest {
         assertEquals(expectedStructType, types[structName])
         assertEquals(
             MapType(
-                "BTreeMap<String, $structName>",
+                "Map<String, $structName>",
                 TypeNest("String", StringType),
                 TypeNest(structName, expectedStructType),
             ),
-            types["BTreeMap<String, $structName>"]
+            types["Map<String, $structName>"]
         )
     }
 
@@ -391,7 +391,7 @@ class SchemaParserTest {
         val schemaJson = """
         {
             "$targetTupleStructName": {
-                "TupleStruct": {
+                "Tuple": {
                     "types": ["$innerStructName"]
                 }
             },

--- a/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/FilterOptIdFilterAccountId.kt
+++ b/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/FilterOptIdFilterAccountId.kt
@@ -8,7 +8,6 @@ import jp.co.soramitsu.iroha2.codec.ScaleCodecReader
 import jp.co.soramitsu.iroha2.codec.ScaleCodecWriter
 import jp.co.soramitsu.iroha2.codec.ScaleReader
 import jp.co.soramitsu.iroha2.codec.ScaleWriter
-import jp.co.soramitsu.iroha2.generated.datamodel.account.Id
 import jp.co.soramitsu.iroha2.wrapException
 import kotlin.Int
 
@@ -49,7 +48,7 @@ public sealed class FilterOptIdFilterAccountId : ModelEnum {
      * 'BySome' variant
      */
     public data class BySome(
-        public val idFilter: IdFilter<Id>
+        public val idFilterAccountId: IdFilterAccountId
     ) : FilterOptIdFilterAccountId() {
         public override fun discriminant(): Int = DISCRIMINANT
 
@@ -58,14 +57,14 @@ public sealed class FilterOptIdFilterAccountId : ModelEnum {
 
             public override fun read(reader: ScaleCodecReader): BySome = try {
                 BySome(
-                    IdFilter.read(reader) as IdFilter<Id>,
+                    IdFilterAccountId.read(reader),
                 )
             } catch (ex: Exception) {
                 throw wrapException(ex)
             }
 
             public override fun write(writer: ScaleCodecWriter, instance: BySome) = try {
-                IdFilter.write(writer, instance.idFilter)
+                IdFilterAccountId.write(writer, instance.idFilterAccountId)
             } catch (ex: Exception) {
                 throw wrapException(ex)
             }

--- a/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/FilterOptIdFilterAssetDefinitionId.kt
+++ b/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/FilterOptIdFilterAssetDefinitionId.kt
@@ -8,7 +8,6 @@ import jp.co.soramitsu.iroha2.codec.ScaleCodecReader
 import jp.co.soramitsu.iroha2.codec.ScaleCodecWriter
 import jp.co.soramitsu.iroha2.codec.ScaleReader
 import jp.co.soramitsu.iroha2.codec.ScaleWriter
-import jp.co.soramitsu.iroha2.generated.datamodel.asset.DefinitionId
 import jp.co.soramitsu.iroha2.wrapException
 import kotlin.Int
 
@@ -49,7 +48,7 @@ public sealed class FilterOptIdFilterAssetDefinitionId : ModelEnum {
      * 'BySome' variant
      */
     public data class BySome(
-        public val idFilter: IdFilter<DefinitionId>
+        public val idFilterAssetDefinitionId: IdFilterAssetDefinitionId
     ) : FilterOptIdFilterAssetDefinitionId() {
         public override fun discriminant(): Int = DISCRIMINANT
 
@@ -58,14 +57,14 @@ public sealed class FilterOptIdFilterAssetDefinitionId : ModelEnum {
 
             public override fun read(reader: ScaleCodecReader): BySome = try {
                 BySome(
-                    IdFilter.read(reader) as IdFilter<DefinitionId>,
+                    IdFilterAssetDefinitionId.read(reader),
                 )
             } catch (ex: Exception) {
                 throw wrapException(ex)
             }
 
             public override fun write(writer: ScaleCodecWriter, instance: BySome) = try {
-                IdFilter.write(writer, instance.idFilter)
+                IdFilterAssetDefinitionId.write(writer, instance.idFilterAssetDefinitionId)
             } catch (ex: Exception) {
                 throw wrapException(ex)
             }

--- a/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/FilterOptIdFilterAssetId.kt
+++ b/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/FilterOptIdFilterAssetId.kt
@@ -8,7 +8,6 @@ import jp.co.soramitsu.iroha2.codec.ScaleCodecReader
 import jp.co.soramitsu.iroha2.codec.ScaleCodecWriter
 import jp.co.soramitsu.iroha2.codec.ScaleReader
 import jp.co.soramitsu.iroha2.codec.ScaleWriter
-import jp.co.soramitsu.iroha2.generated.datamodel.asset.Id
 import jp.co.soramitsu.iroha2.wrapException
 import kotlin.Int
 
@@ -49,7 +48,7 @@ public sealed class FilterOptIdFilterAssetId : ModelEnum {
      * 'BySome' variant
      */
     public data class BySome(
-        public val idFilter: IdFilter<Id>
+        public val idFilterAssetId: IdFilterAssetId
     ) : FilterOptIdFilterAssetId() {
         public override fun discriminant(): Int = DISCRIMINANT
 
@@ -58,14 +57,14 @@ public sealed class FilterOptIdFilterAssetId : ModelEnum {
 
             public override fun read(reader: ScaleCodecReader): BySome = try {
                 BySome(
-                    IdFilter.read(reader) as IdFilter<Id>,
+                    IdFilterAssetId.read(reader),
                 )
             } catch (ex: Exception) {
                 throw wrapException(ex)
             }
 
             public override fun write(writer: ScaleCodecWriter, instance: BySome) = try {
-                IdFilter.write(writer, instance.idFilter)
+                IdFilterAssetId.write(writer, instance.idFilterAssetId)
             } catch (ex: Exception) {
                 throw wrapException(ex)
             }

--- a/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/FilterOptIdFilterDomainId.kt
+++ b/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/FilterOptIdFilterDomainId.kt
@@ -8,7 +8,6 @@ import jp.co.soramitsu.iroha2.codec.ScaleCodecReader
 import jp.co.soramitsu.iroha2.codec.ScaleCodecWriter
 import jp.co.soramitsu.iroha2.codec.ScaleReader
 import jp.co.soramitsu.iroha2.codec.ScaleWriter
-import jp.co.soramitsu.iroha2.generated.datamodel.domain.Id
 import jp.co.soramitsu.iroha2.wrapException
 import kotlin.Int
 
@@ -49,7 +48,7 @@ public sealed class FilterOptIdFilterDomainId : ModelEnum {
      * 'BySome' variant
      */
     public data class BySome(
-        public val idFilter: IdFilter<Id>
+        public val idFilterDomainId: IdFilterDomainId
     ) : FilterOptIdFilterDomainId() {
         public override fun discriminant(): Int = DISCRIMINANT
 
@@ -58,14 +57,14 @@ public sealed class FilterOptIdFilterDomainId : ModelEnum {
 
             public override fun read(reader: ScaleCodecReader): BySome = try {
                 BySome(
-                    IdFilter.read(reader) as IdFilter<Id>,
+                    IdFilterDomainId.read(reader),
                 )
             } catch (ex: Exception) {
                 throw wrapException(ex)
             }
 
             public override fun write(writer: ScaleCodecWriter, instance: BySome) = try {
-                IdFilter.write(writer, instance.idFilter)
+                IdFilterDomainId.write(writer, instance.idFilterDomainId)
             } catch (ex: Exception) {
                 throw wrapException(ex)
             }

--- a/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/FilterOptIdFilterPeerId.kt
+++ b/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/FilterOptIdFilterPeerId.kt
@@ -8,7 +8,6 @@ import jp.co.soramitsu.iroha2.codec.ScaleCodecReader
 import jp.co.soramitsu.iroha2.codec.ScaleCodecWriter
 import jp.co.soramitsu.iroha2.codec.ScaleReader
 import jp.co.soramitsu.iroha2.codec.ScaleWriter
-import jp.co.soramitsu.iroha2.generated.datamodel.peer.Id
 import jp.co.soramitsu.iroha2.wrapException
 import kotlin.Int
 
@@ -49,7 +48,7 @@ public sealed class FilterOptIdFilterPeerId : ModelEnum {
      * 'BySome' variant
      */
     public data class BySome(
-        public val idFilter: IdFilter<Id>
+        public val idFilterPeerId: IdFilterPeerId
     ) : FilterOptIdFilterPeerId() {
         public override fun discriminant(): Int = DISCRIMINANT
 
@@ -58,14 +57,14 @@ public sealed class FilterOptIdFilterPeerId : ModelEnum {
 
             public override fun read(reader: ScaleCodecReader): BySome = try {
                 BySome(
-                    IdFilter.read(reader) as IdFilter<Id>,
+                    IdFilterPeerId.read(reader),
                 )
             } catch (ex: Exception) {
                 throw wrapException(ex)
             }
 
             public override fun write(writer: ScaleCodecWriter, instance: BySome) = try {
-                IdFilter.write(writer, instance.idFilter)
+                IdFilterPeerId.write(writer, instance.idFilterPeerId)
             } catch (ex: Exception) {
                 throw wrapException(ex)
             }

--- a/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/FilterOptIdFilterRoleId.kt
+++ b/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/FilterOptIdFilterRoleId.kt
@@ -8,7 +8,6 @@ import jp.co.soramitsu.iroha2.codec.ScaleCodecReader
 import jp.co.soramitsu.iroha2.codec.ScaleCodecWriter
 import jp.co.soramitsu.iroha2.codec.ScaleReader
 import jp.co.soramitsu.iroha2.codec.ScaleWriter
-import jp.co.soramitsu.iroha2.generated.datamodel.role.Id
 import jp.co.soramitsu.iroha2.wrapException
 import kotlin.Int
 
@@ -49,7 +48,7 @@ public sealed class FilterOptIdFilterRoleId : ModelEnum {
      * 'BySome' variant
      */
     public data class BySome(
-        public val idFilter: IdFilter<Id>
+        public val idFilterRoleId: IdFilterRoleId
     ) : FilterOptIdFilterRoleId() {
         public override fun discriminant(): Int = DISCRIMINANT
 
@@ -58,14 +57,14 @@ public sealed class FilterOptIdFilterRoleId : ModelEnum {
 
             public override fun read(reader: ScaleCodecReader): BySome = try {
                 BySome(
-                    IdFilter.read(reader) as IdFilter<Id>,
+                    IdFilterRoleId.read(reader),
                 )
             } catch (ex: Exception) {
                 throw wrapException(ex)
             }
 
             public override fun write(writer: ScaleCodecWriter, instance: BySome) = try {
-                IdFilter.write(writer, instance.idFilter)
+                IdFilterRoleId.write(writer, instance.idFilterRoleId)
             } catch (ex: Exception) {
                 throw wrapException(ex)
             }

--- a/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/FilterOptIdFilterTriggerId.kt
+++ b/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/FilterOptIdFilterTriggerId.kt
@@ -8,7 +8,6 @@ import jp.co.soramitsu.iroha2.codec.ScaleCodecReader
 import jp.co.soramitsu.iroha2.codec.ScaleCodecWriter
 import jp.co.soramitsu.iroha2.codec.ScaleReader
 import jp.co.soramitsu.iroha2.codec.ScaleWriter
-import jp.co.soramitsu.iroha2.generated.datamodel.trigger.Id
 import jp.co.soramitsu.iroha2.wrapException
 import kotlin.Int
 
@@ -49,7 +48,7 @@ public sealed class FilterOptIdFilterTriggerId : ModelEnum {
      * 'BySome' variant
      */
     public data class BySome(
-        public val idFilter: IdFilter<Id>
+        public val idFilterTriggerId: IdFilterTriggerId
     ) : FilterOptIdFilterTriggerId() {
         public override fun discriminant(): Int = DISCRIMINANT
 
@@ -58,14 +57,14 @@ public sealed class FilterOptIdFilterTriggerId : ModelEnum {
 
             public override fun read(reader: ScaleCodecReader): BySome = try {
                 BySome(
-                    IdFilter.read(reader) as IdFilter<Id>,
+                    IdFilterTriggerId.read(reader),
                 )
             } catch (ex: Exception) {
                 throw wrapException(ex)
             }
 
             public override fun write(writer: ScaleCodecWriter, instance: BySome) = try {
-                IdFilter.write(writer, instance.idFilter)
+                IdFilterTriggerId.write(writer, instance.idFilterTriggerId)
             } catch (ex: Exception) {
                 throw wrapException(ex)
             }

--- a/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/IdFilterAccountId.kt
+++ b/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/IdFilterAccountId.kt
@@ -1,0 +1,36 @@
+//
+// Auto-generated file. DO NOT EDIT!
+//
+package jp.co.soramitsu.iroha2.generated.datamodel.events.`data`.filters
+
+import jp.co.soramitsu.iroha2.codec.ScaleCodecReader
+import jp.co.soramitsu.iroha2.codec.ScaleCodecWriter
+import jp.co.soramitsu.iroha2.codec.ScaleReader
+import jp.co.soramitsu.iroha2.codec.ScaleWriter
+import jp.co.soramitsu.iroha2.generated.datamodel.account.Id
+import jp.co.soramitsu.iroha2.wrapException
+
+/**
+ * IdFilterAccountId
+ *
+ * Generated from 'iroha_data_model::events::data::filters::IdFilterAccountId' tuple structure
+ */
+public data class IdFilterAccountId(
+    public val id: Id
+) {
+    public companion object : ScaleReader<IdFilterAccountId>, ScaleWriter<IdFilterAccountId> {
+        public override fun read(reader: ScaleCodecReader): IdFilterAccountId = try {
+            IdFilterAccountId(
+                Id.read(reader),
+            )
+        } catch (ex: Exception) {
+            throw wrapException(ex)
+        }
+
+        public override fun write(writer: ScaleCodecWriter, instance: IdFilterAccountId) = try {
+            Id.write(writer, instance.id)
+        } catch (ex: Exception) {
+            throw wrapException(ex)
+        }
+    }
+}

--- a/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/IdFilterAssetDefinitionId.kt
+++ b/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/IdFilterAssetDefinitionId.kt
@@ -1,0 +1,39 @@
+//
+// Auto-generated file. DO NOT EDIT!
+//
+package jp.co.soramitsu.iroha2.generated.datamodel.events.`data`.filters
+
+import jp.co.soramitsu.iroha2.codec.ScaleCodecReader
+import jp.co.soramitsu.iroha2.codec.ScaleCodecWriter
+import jp.co.soramitsu.iroha2.codec.ScaleReader
+import jp.co.soramitsu.iroha2.codec.ScaleWriter
+import jp.co.soramitsu.iroha2.generated.datamodel.asset.DefinitionId
+import jp.co.soramitsu.iroha2.wrapException
+
+/**
+ * IdFilterAssetDefinitionId
+ *
+ * Generated from 'iroha_data_model::events::data::filters::IdFilterAssetDefinitionId' tuple
+ * structure
+ */
+public data class IdFilterAssetDefinitionId(
+    public val definitionId: DefinitionId
+) {
+    public companion object :
+        ScaleReader<IdFilterAssetDefinitionId>,
+        ScaleWriter<IdFilterAssetDefinitionId> {
+        public override fun read(reader: ScaleCodecReader): IdFilterAssetDefinitionId = try {
+            IdFilterAssetDefinitionId(
+                DefinitionId.read(reader),
+            )
+        } catch (ex: Exception) {
+            throw wrapException(ex)
+        }
+
+        public override fun write(writer: ScaleCodecWriter, instance: IdFilterAssetDefinitionId) = try {
+            DefinitionId.write(writer, instance.definitionId)
+        } catch (ex: Exception) {
+            throw wrapException(ex)
+        }
+    }
+}

--- a/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/IdFilterAssetId.kt
+++ b/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/IdFilterAssetId.kt
@@ -7,29 +7,27 @@ import jp.co.soramitsu.iroha2.codec.ScaleCodecReader
 import jp.co.soramitsu.iroha2.codec.ScaleCodecWriter
 import jp.co.soramitsu.iroha2.codec.ScaleReader
 import jp.co.soramitsu.iroha2.codec.ScaleWriter
-import jp.co.soramitsu.iroha2.generated.datamodel.trigger.Id
+import jp.co.soramitsu.iroha2.generated.datamodel.asset.Id
 import jp.co.soramitsu.iroha2.wrapException
-import kotlin.Any
 
 /**
- * IdFilter
+ * IdFilterAssetId
  *
- * Generated from 'iroha_data_model::events::data::filters::IdFilter<iroha_data_model::trigger::Id>'
- * tuple structure
+ * Generated from 'iroha_data_model::events::data::filters::IdFilterAssetId' tuple structure
  */
-public data class IdFilter<T0>(
+public data class IdFilterAssetId(
     public val id: Id
 ) {
-    public companion object : ScaleReader<IdFilter<out Any>>, ScaleWriter<IdFilter<out Any>> {
-        public override fun read(reader: ScaleCodecReader): IdFilter<out Any> = try {
-            IdFilter(
+    public companion object : ScaleReader<IdFilterAssetId>, ScaleWriter<IdFilterAssetId> {
+        public override fun read(reader: ScaleCodecReader): IdFilterAssetId = try {
+            IdFilterAssetId(
                 Id.read(reader),
             )
         } catch (ex: Exception) {
             throw wrapException(ex)
         }
 
-        public override fun write(writer: ScaleCodecWriter, instance: IdFilter<out Any>) = try {
+        public override fun write(writer: ScaleCodecWriter, instance: IdFilterAssetId) = try {
             Id.write(writer, instance.id)
         } catch (ex: Exception) {
             throw wrapException(ex)

--- a/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/IdFilterDomainId.kt
+++ b/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/IdFilterDomainId.kt
@@ -1,0 +1,36 @@
+//
+// Auto-generated file. DO NOT EDIT!
+//
+package jp.co.soramitsu.iroha2.generated.datamodel.events.`data`.filters
+
+import jp.co.soramitsu.iroha2.codec.ScaleCodecReader
+import jp.co.soramitsu.iroha2.codec.ScaleCodecWriter
+import jp.co.soramitsu.iroha2.codec.ScaleReader
+import jp.co.soramitsu.iroha2.codec.ScaleWriter
+import jp.co.soramitsu.iroha2.generated.datamodel.domain.Id
+import jp.co.soramitsu.iroha2.wrapException
+
+/**
+ * IdFilterDomainId
+ *
+ * Generated from 'iroha_data_model::events::data::filters::IdFilterDomainId' tuple structure
+ */
+public data class IdFilterDomainId(
+    public val id: Id
+) {
+    public companion object : ScaleReader<IdFilterDomainId>, ScaleWriter<IdFilterDomainId> {
+        public override fun read(reader: ScaleCodecReader): IdFilterDomainId = try {
+            IdFilterDomainId(
+                Id.read(reader),
+            )
+        } catch (ex: Exception) {
+            throw wrapException(ex)
+        }
+
+        public override fun write(writer: ScaleCodecWriter, instance: IdFilterDomainId) = try {
+            Id.write(writer, instance.id)
+        } catch (ex: Exception) {
+            throw wrapException(ex)
+        }
+    }
+}

--- a/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/IdFilterPeerId.kt
+++ b/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/IdFilterPeerId.kt
@@ -1,0 +1,36 @@
+//
+// Auto-generated file. DO NOT EDIT!
+//
+package jp.co.soramitsu.iroha2.generated.datamodel.events.`data`.filters
+
+import jp.co.soramitsu.iroha2.codec.ScaleCodecReader
+import jp.co.soramitsu.iroha2.codec.ScaleCodecWriter
+import jp.co.soramitsu.iroha2.codec.ScaleReader
+import jp.co.soramitsu.iroha2.codec.ScaleWriter
+import jp.co.soramitsu.iroha2.generated.datamodel.peer.Id
+import jp.co.soramitsu.iroha2.wrapException
+
+/**
+ * IdFilterPeerId
+ *
+ * Generated from 'iroha_data_model::events::data::filters::IdFilterPeerId' tuple structure
+ */
+public data class IdFilterPeerId(
+    public val id: Id
+) {
+    public companion object : ScaleReader<IdFilterPeerId>, ScaleWriter<IdFilterPeerId> {
+        public override fun read(reader: ScaleCodecReader): IdFilterPeerId = try {
+            IdFilterPeerId(
+                Id.read(reader),
+            )
+        } catch (ex: Exception) {
+            throw wrapException(ex)
+        }
+
+        public override fun write(writer: ScaleCodecWriter, instance: IdFilterPeerId) = try {
+            Id.write(writer, instance.id)
+        } catch (ex: Exception) {
+            throw wrapException(ex)
+        }
+    }
+}

--- a/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/IdFilterRoleId.kt
+++ b/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/IdFilterRoleId.kt
@@ -1,0 +1,36 @@
+//
+// Auto-generated file. DO NOT EDIT!
+//
+package jp.co.soramitsu.iroha2.generated.datamodel.events.`data`.filters
+
+import jp.co.soramitsu.iroha2.codec.ScaleCodecReader
+import jp.co.soramitsu.iroha2.codec.ScaleCodecWriter
+import jp.co.soramitsu.iroha2.codec.ScaleReader
+import jp.co.soramitsu.iroha2.codec.ScaleWriter
+import jp.co.soramitsu.iroha2.generated.datamodel.role.Id
+import jp.co.soramitsu.iroha2.wrapException
+
+/**
+ * IdFilterRoleId
+ *
+ * Generated from 'iroha_data_model::events::data::filters::IdFilterRoleId' tuple structure
+ */
+public data class IdFilterRoleId(
+    public val id: Id
+) {
+    public companion object : ScaleReader<IdFilterRoleId>, ScaleWriter<IdFilterRoleId> {
+        public override fun read(reader: ScaleCodecReader): IdFilterRoleId = try {
+            IdFilterRoleId(
+                Id.read(reader),
+            )
+        } catch (ex: Exception) {
+            throw wrapException(ex)
+        }
+
+        public override fun write(writer: ScaleCodecWriter, instance: IdFilterRoleId) = try {
+            Id.write(writer, instance.id)
+        } catch (ex: Exception) {
+            throw wrapException(ex)
+        }
+    }
+}

--- a/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/IdFilterTriggerId.kt
+++ b/modules/model/src/main/kotlin/jp/co/soramitsu/iroha2/generated/datamodel/events/data/filters/IdFilterTriggerId.kt
@@ -1,0 +1,36 @@
+//
+// Auto-generated file. DO NOT EDIT!
+//
+package jp.co.soramitsu.iroha2.generated.datamodel.events.`data`.filters
+
+import jp.co.soramitsu.iroha2.codec.ScaleCodecReader
+import jp.co.soramitsu.iroha2.codec.ScaleCodecWriter
+import jp.co.soramitsu.iroha2.codec.ScaleReader
+import jp.co.soramitsu.iroha2.codec.ScaleWriter
+import jp.co.soramitsu.iroha2.generated.datamodel.trigger.Id
+import jp.co.soramitsu.iroha2.wrapException
+
+/**
+ * IdFilterTriggerId
+ *
+ * Generated from 'iroha_data_model::events::data::filters::IdFilterTriggerId' tuple structure
+ */
+public data class IdFilterTriggerId(
+    public val id: Id
+) {
+    public companion object : ScaleReader<IdFilterTriggerId>, ScaleWriter<IdFilterTriggerId> {
+        public override fun read(reader: ScaleCodecReader): IdFilterTriggerId = try {
+            IdFilterTriggerId(
+                Id.read(reader),
+            )
+        } catch (ex: Exception) {
+            throw wrapException(ex)
+        }
+
+        public override fun write(writer: ScaleCodecWriter, instance: IdFilterTriggerId) = try {
+            Id.write(writer, instance.id)
+        } catch (ex: Exception) {
+            throw wrapException(ex)
+        }
+    }
+}


### PR DESCRIPTION
Changes:
1. Register event trigger refactoring
2. Cherry-pick iroha-219 issue schema changes
3. Added in-memory changes to iroha_data_model types that contains "data::filters" before generating code. For example this:
iroha_data_model::events::data::filters::FilterOpt<iroha_data_model::events::data::filters::IdFilter<iroha_data_model::account::Id>>
Becomes:
iroha_data_model::events::data::filters::FilterOptIdFilterAccountId