### PR TITLE
[refactor]: Rename `KURA_BLOCK_STORE_PATH` in `config.json`

### DIFF
--- a/modules/testcontainers/src/main/resources/config.json
+++ b/modules/testcontainers/src/main/resources/config.json
@@ -14,7 +14,7 @@
   },
   "KURA": {
     "BLOCKS_PER_STORAGE_FILE": 1000,
-    "BLOCK_STORE_PATH": "./blocks",
+    "BLOCK_STORE_PATH": "./storage",
     "INIT_MODE": "strict",
     "MAILBOX": 100
   },


### PR DESCRIPTION
Just for consistency with the change of `DEFAULT_BLOCK_STORE_PATH` from `./blocks` to `./storage` in https://github.com/hyperledger/iroha/pull/2701
