### PR TITLE
dops-2034: increase tests logs level

### DIFF
--- a/.github/workflows/iroha2-pr.yml
+++ b/.github/workflows/iroha2-pr.yml
@@ -23,7 +23,13 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew build --info
+      - name: Upload build reports
+        if: failure()
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-reports
+          path: /home/runner/work/iroha-java/iroha-java/**/index.html
       - name: Cleanup Gradle Cache
         # Remove some files from the Gradle cache, so they aren't cached by GitHub Actions.
         # Restoring these files from a GitHub Actions cache might cause problems for future builds.


### PR DESCRIPTION
Signed-off-by: BAStos525 <jungle.vas@yandex.ru>

###Feature
1. Increase `gradle` build log level.
2. Upload gradle `report.html` file as Actions artifact.