### PR TITLE
fix "bind: address already in use"

### DIFF
--- a/modules/client/src/main/kotlin/jp/co/soramitsu/iroha2/Utils.kt
+++ b/modules/client/src/main/kotlin/jp/co/soramitsu/iroha2/Utils.kt
@@ -13,7 +13,9 @@ suspend fun findFreePorts(
 ): List<Int> {
     fun find() = (0 until amount).map {
         try {
-            ServerSocket(0).use { it.localPort }
+            val socket = ServerSocket(0)
+            socket.soTimeout = 300 // seconds
+            socket.use { it.localPort }
         } catch (e: IOException) {
             throw e
         }

--- a/modules/client/src/test/kotlin/jp/co/soramitsu/iroha2/TriggersTest.kt
+++ b/modules/client/src/test/kotlin/jp/co/soramitsu/iroha2/TriggersTest.kt
@@ -234,21 +234,15 @@ class TriggersTest : IrohaTest<Iroha2Client>() {
         }
 
         // send some transactions to keep Iroha2 network busy
-        client.sendTransaction {
-            accountId = ALICE_ACCOUNT_ID
-            setKeyValue(ALICE_ACCOUNT_ID, "test".asName(), "test".asValue())
-            buildSigned(ALICE_KEYPAIR)
-        }.also { d ->
-            withTimeout(txTimeout) { d.await() }
+        repeat(2) { i ->
+            client.sendTransaction {
+                accountId = ALICE_ACCOUNT_ID
+                setKeyValue(ALICE_ACCOUNT_ID, "test$i".asName(), "test$i".asValue())
+                buildSigned(ALICE_KEYPAIR)
+            }.also { d ->
+                withTimeout(txTimeout) { d.await() }
+            }
         }
-        client.sendTransaction {
-            accountId = ALICE_ACCOUNT_ID
-            setKeyValue(ALICE_ACCOUNT_ID, "test2".asName(), "test2".asValue())
-            buildSigned(ALICE_KEYPAIR)
-        }.also { d ->
-            withTimeout(txTimeout) { d.await() }
-        }
-
         QueryBuilder.findAssetsByAccountId(ALICE_ACCOUNT_ID)
             .account(ALICE_ACCOUNT_ID)
             .buildSigned(ALICE_KEYPAIR)


### PR DESCRIPTION
- findFreePorts function fixed by adding socket timeout (to not use port after all tests are done)
- containers initialize before anything (need to make `containers` property initialized in IrohaTest earlier the `@BeforeEach` method called)

Signed-off-by: akostiucenko <kostiuchenko@soramitsu.co.jp>