### PR TITLE
feature: get executor from test resource folder

### DIFF
--- a/modules/test-tools/src/main/kotlin/jp/co/soramitsu/iroha2/testengine/IrohaConfig.kt
+++ b/modules/test-tools/src/main/kotlin/jp/co/soramitsu/iroha2/testengine/IrohaConfig.kt
@@ -43,6 +43,7 @@ class IrohaConfig(
     var submitGenesis: Boolean = true,
     var envs: Map<String, String> = emptyMap(),
     var fetchSize: Int = 10,
+    var useLocalTestExecutor: Boolean = false,
 ) {
     companion object {
         const val P2P_PORT_IDX = 0

--- a/modules/test-tools/src/main/kotlin/jp/co/soramitsu/iroha2/testengine/IrohaConfig.kt
+++ b/modules/test-tools/src/main/kotlin/jp/co/soramitsu/iroha2/testengine/IrohaConfig.kt
@@ -43,7 +43,7 @@ class IrohaConfig(
     var submitGenesis: Boolean = true,
     var envs: Map<String, String> = emptyMap(),
     var fetchSize: Int = 10,
-    var useLocalTestExecutor: Boolean = false,
+    var executorPath: String? = null,
 ) {
     companion object {
         const val P2P_PORT_IDX = 0

--- a/modules/test-tools/src/main/kotlin/jp/co/soramitsu/iroha2/testengine/IrohaContainer.kt
+++ b/modules/test-tools/src/main/kotlin/jp/co/soramitsu/iroha2/testengine/IrohaContainer.kt
@@ -9,7 +9,6 @@ import org.testcontainers.containers.wait.strategy.HttpWaitStrategy
 import org.testcontainers.shaded.com.google.common.io.Resources.getResource
 import org.testcontainers.utility.DockerImageName
 import org.testcontainers.utility.MountableFile.forHostPath
-import java.io.File
 import java.io.IOException
 import java.net.URL
 import java.nio.file.Files
@@ -74,10 +73,8 @@ open class IrohaContainer : GenericContainer<IrohaContainer> {
                 config.genesis?.writeToFile(genesisFileLocation)
                 config.genesisPath?.also { path -> Files.copy(Path(path).toAbsolutePath(), genesisFileLocation) }
 
-                if (config.useLocalTestExecutor) {
-                    val pathToCustomExecutor = "${System.getProperty("user.dir")}${File.separator}src${File.separator}test" +
-                        "${File.separator}resources${File.separator}$DEFAULT_EXECUTOR_FILE_NAME"
-                    Path(pathToCustomExecutor).readBytes().let { content ->
+                if (config.executorPath != null) {
+                    Path(config.executorPath!!).toAbsolutePath().readBytes().let { content ->
                         executorFileLocation.toFile().writeBytes(content)
                     }
                 } else {

--- a/modules/test-tools/src/main/kotlin/jp/co/soramitsu/iroha2/testengine/IrohaContainer.kt
+++ b/modules/test-tools/src/main/kotlin/jp/co/soramitsu/iroha2/testengine/IrohaContainer.kt
@@ -9,6 +9,7 @@ import org.testcontainers.containers.wait.strategy.HttpWaitStrategy
 import org.testcontainers.shaded.com.google.common.io.Resources.getResource
 import org.testcontainers.utility.DockerImageName
 import org.testcontainers.utility.MountableFile.forHostPath
+import java.io.File
 import java.io.IOException
 import java.net.URL
 import java.nio.file.Files
@@ -16,6 +17,7 @@ import java.time.Duration
 import java.util.UUID.randomUUID
 import kotlin.io.path.Path
 import kotlin.io.path.absolute
+import kotlin.io.path.readBytes
 
 /**
  * Docker container for Iroha
@@ -72,8 +74,16 @@ open class IrohaContainer : GenericContainer<IrohaContainer> {
                 config.genesis?.writeToFile(genesisFileLocation)
                 config.genesisPath?.also { path -> Files.copy(Path(path).toAbsolutePath(), genesisFileLocation) }
 
-                getResource(DEFAULT_EXECUTOR_FILE_NAME).readBytes().let { content ->
-                    executorFileLocation.toFile().writeBytes(content)
+                if (config.useLocalTestExecutor) {
+                    val pathToCustomExecutor = "${System.getProperty("user.dir")}${File.separator}src${File.separator}test" +
+                        "${File.separator}resources${File.separator}$DEFAULT_EXECUTOR_FILE_NAME"
+                    Path(pathToCustomExecutor).readBytes().let { content ->
+                        executorFileLocation.toFile().writeBytes(content)
+                    }
+                } else {
+                    getResource(DEFAULT_EXECUTOR_FILE_NAME).readBytes().let { content ->
+                        executorFileLocation.toFile().writeBytes(content)
+                    }
                 }
                 getResource(DEFAULT_CONFIG_FILE_NAME).readBytes().let { content ->
                     configFileLocation.toFile().writeBytes(content)

--- a/modules/test-tools/src/main/kotlin/jp/co/soramitsu/iroha2/testengine/IrohaRunnerExtension.kt
+++ b/modules/test-tools/src/main/kotlin/jp/co/soramitsu/iroha2/testengine/IrohaRunnerExtension.kt
@@ -246,6 +246,7 @@ class IrohaRunnerExtension : InvocationInterceptor, BeforeEachCallback {
                     }
                     // only first peer should have --submit-genesis in peer start command
                     this.submitGenesis = n == 0
+                    this.useLocalTestExecutor = withIroha.useLocalTestExecutor
                 }
                 container.start()
                 containers.add(container)

--- a/modules/test-tools/src/main/kotlin/jp/co/soramitsu/iroha2/testengine/IrohaRunnerExtension.kt
+++ b/modules/test-tools/src/main/kotlin/jp/co/soramitsu/iroha2/testengine/IrohaRunnerExtension.kt
@@ -246,7 +246,9 @@ class IrohaRunnerExtension : InvocationInterceptor, BeforeEachCallback {
                     }
                     // only first peer should have --submit-genesis in peer start command
                     this.submitGenesis = n == 0
-                    this.useLocalTestExecutor = withIroha.useLocalTestExecutor
+                    if (withIroha.executorSource.isNotEmpty()) {
+                        this.executorPath = withIroha.executorSource
+                    }
                 }
                 container.start()
                 containers.add(container)

--- a/modules/test-tools/src/main/kotlin/jp/co/soramitsu/iroha2/testengine/WithIroha.kt
+++ b/modules/test-tools/src/main/kotlin/jp/co/soramitsu/iroha2/testengine/WithIroha.kt
@@ -23,7 +23,7 @@ annotation class WithIroha(
     val source: String = "",
     val amount: Int = 1,
     val fetchSize: Int = 10,
-    val useLocalTestExecutor: Boolean = false,
+    val executorSource: String = "",
 )
 
 @MustBeDocumented

--- a/modules/test-tools/src/main/kotlin/jp/co/soramitsu/iroha2/testengine/WithIroha.kt
+++ b/modules/test-tools/src/main/kotlin/jp/co/soramitsu/iroha2/testengine/WithIroha.kt
@@ -23,6 +23,7 @@ annotation class WithIroha(
     val source: String = "",
     val amount: Int = 1,
     val fetchSize: Int = 10,
+    val useLocalTestExecutor: Boolean = false,
 )
 
 @MustBeDocumented


### PR DESCRIPTION
In order to run local tests with custom executor:
add custom executor to resource test folder and set flag to true