### PR TITLE
chore: update actions

### DIFF
--- a/.github/workflows/iroha2-pr.yml
+++ b/.github/workflows/iroha2-pr.yml
@@ -10,7 +10,7 @@ jobs:
     env:
       IROHA_IMAGE_TAG: "2.0.0-pre-rc.22.2" # Place "dev" to run on the last iroha
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:
@@ -29,7 +29,7 @@ jobs:
         run: ./gradlew build --info
       - name: Upload build reports
         if: failure()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-reports
           path: /home/runner/work/iroha-java/iroha-java/**/index.html


### PR DESCRIPTION
actions/upload-artifact and actions/download-artifact have been deprecated and need updated.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/